### PR TITLE
feat: tasks page API — slash commands, skills, subagent aggregates

### DIFF
--- a/burnmap/__init__.py
+++ b/burnmap/__init__.py
@@ -1,0 +1,1 @@
+# t01-burnmap — local-first AI coding agent token usage dashboard

--- a/burnmap/api/__init__.py
+++ b/burnmap/api/__init__.py
@@ -1,0 +1,3 @@
+from .tasks import router as tasks_router
+
+__all__ = ["tasks_router"]

--- a/burnmap/api/tasks.py
+++ b/burnmap/api/tasks.py
@@ -1,0 +1,90 @@
+"""/api/tasks — aggregated slash commands, skills, and subagent task data."""
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends, Query
+    from fastapi.responses import JSONResponse
+    _FASTAPI = True
+except ImportError:  # allow import without FastAPI for testing
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/tasks")
+    def list_tasks(
+        kind: str | None = Query(None, description="Filter by kind: slash|skill|subagent"),
+        limit: int = Query(100, ge=1, le=1000),
+        db: sqlite3.Connection = Depends(_db),
+    ) -> JSONResponse:
+        rows = query_tasks(db, kind=kind, limit=limit)
+        return JSONResponse({"tasks": rows})
+else:
+    router = None  # type: ignore[assignment]
+
+
+# ── Pure query function (testable without FastAPI) ───────────────────────────
+
+_VALID_KINDS = {"slash", "skill", "subagent"}
+
+
+def query_tasks(
+    conn: sqlite3.Connection,
+    *,
+    kind: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return aggregated task rows from the spans table.
+
+    Each row contains:
+      name, kind, calls, total_input_tokens, total_output_tokens,
+      avg_tokens_per_call, total_cost_usd, last_seen_ms
+    """
+    where = ""
+    params: list[Any] = []
+
+    if kind is not None:
+        if kind not in _VALID_KINDS:
+            return []
+        where = "WHERE kind = ?"
+        params.append(kind)
+    else:
+        placeholders = ",".join("?" * len(_VALID_KINDS))
+        where = f"WHERE kind IN ({placeholders})"
+        params.extend(sorted(_VALID_KINDS))
+
+    sql = f"""
+        SELECT
+            name,
+            kind,
+            COUNT(*)                                        AS calls,
+            SUM(input_tokens)                               AS total_input_tokens,
+            SUM(output_tokens)                              AS total_output_tokens,
+            CAST(
+              (SUM(input_tokens) + SUM(output_tokens)) AS REAL
+            ) / COUNT(*)                                    AS avg_tokens_per_call,
+            SUM(cost_usd)                                   AS total_cost_usd,
+            MAX(started_at)                                 AS last_seen_ms
+        FROM spans
+        {where}
+        GROUP BY name, kind
+        ORDER BY total_cost_usd DESC
+        LIMIT ?
+    """
+    params.append(limit)
+
+    cur = conn.execute(sql, params)
+    return [dict(row) for row in cur.fetchall()]

--- a/burnmap/db/__init__.py
+++ b/burnmap/db/__init__.py
@@ -1,0 +1,3 @@
+from .schema import get_db, init_db
+
+__all__ = ["get_db", "init_db"]

--- a/burnmap/db/schema.py
+++ b/burnmap/db/schema.py
@@ -1,0 +1,39 @@
+"""Minimal SQLite schema and connection helper for t01-burnmap."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_DEFAULT_DB = Path.home() / ".t01-burnmap" / "usage.db"
+
+
+def get_db(path: str | Path | None = None) -> sqlite3.Connection:
+    """Return an open WAL-mode SQLite connection."""
+    db_path = Path(path) if path else _DEFAULT_DB
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """Create tables if they don't exist."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS spans (
+            id          TEXT PRIMARY KEY,
+            session_id  TEXT NOT NULL,
+            agent       TEXT NOT NULL,
+            kind        TEXT NOT NULL,   -- 'slash' | 'skill' | 'subagent' | 'tool' | 'turn'
+            name        TEXT NOT NULL,   -- slash command name, skill name, or subagent label
+            input_tokens  INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cost_usd      REAL    DEFAULT 0.0,
+            started_at    INTEGER DEFAULT 0  -- epoch ms
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_spans_kind ON spans(kind);
+        CREATE INDEX IF NOT EXISTS idx_spans_name ON spans(name);
+    """)
+    conn.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "t01-burnmap"
+version = "0.1.0"
+description = "Local-first AI coding agent token usage dashboard"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-asyncio"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["burnmap*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1,0 +1,108 @@
+"""Tests for /api/tasks query logic (no FastAPI runtime needed)."""
+import sqlite3
+
+import pytest
+
+from burnmap.api.tasks import query_tasks, _VALID_KINDS
+from burnmap.db.schema import init_db
+
+
+@pytest.fixture
+def db():
+    """In-memory SQLite with schema and seed data."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    _seed(conn)
+    yield conn
+    conn.close()
+
+
+def _seed(conn: sqlite3.Connection) -> None:
+    rows = [
+        # id, session_id, agent, kind, name, input_tokens, output_tokens, cost_usd, started_at
+        ("s1", "sess-a", "claude_code", "slash",   "/commit",     800, 200, 0.012, 1_700_000_000_000),
+        ("s2", "sess-a", "claude_code", "slash",   "/commit",     600, 150, 0.009, 1_700_000_001_000),
+        ("s3", "sess-b", "claude_code", "skill",   "battle-qa",  1200, 300, 0.020, 1_700_000_002_000),
+        ("s4", "sess-b", "claude_code", "subagent", "implement",  2000, 500, 0.035, 1_700_000_003_000),
+        ("s5", "sess-c", "claude_code", "skill",   "battle-qa",   900, 250, 0.015, 1_700_000_004_000),
+        # "tool" kind — should NOT appear in tasks results
+        ("s6", "sess-c", "claude_code", "tool",    "Read",         0,   0, 0.0,   1_700_000_005_000),
+    ]
+    conn.executemany(
+        "INSERT INTO spans VALUES (?,?,?,?,?,?,?,?,?)", rows
+    )
+    conn.commit()
+
+
+class TestQueryTasks:
+    def test_returns_only_task_kinds(self, db):
+        rows = query_tasks(db)
+        kinds = {r["kind"] for r in rows}
+        assert kinds <= _VALID_KINDS
+        assert "tool" not in kinds
+
+    def test_aggregates_calls(self, db):
+        rows = query_tasks(db)
+        commit_row = next(r for r in rows if r["name"] == "/commit")
+        assert commit_row["calls"] == 2
+
+    def test_token_sums(self, db):
+        rows = query_tasks(db)
+        commit_row = next(r for r in rows if r["name"] == "/commit")
+        assert commit_row["total_input_tokens"] == 1400
+        assert commit_row["total_output_tokens"] == 350
+
+    def test_avg_tokens_per_call(self, db):
+        rows = query_tasks(db)
+        commit_row = next(r for r in rows if r["name"] == "/commit")
+        # (800+200+600+150) / 2 = 875
+        assert commit_row["avg_tokens_per_call"] == pytest.approx(875.0)
+
+    def test_cost_sum(self, db):
+        rows = query_tasks(db)
+        commit_row = next(r for r in rows if r["name"] == "/commit")
+        assert commit_row["total_cost_usd"] == pytest.approx(0.021)
+
+    def test_last_seen_ms(self, db):
+        rows = query_tasks(db)
+        commit_row = next(r for r in rows if r["name"] == "/commit")
+        assert commit_row["last_seen_ms"] == 1_700_000_001_000
+
+    def test_ordered_by_cost_desc(self, db):
+        rows = query_tasks(db)
+        costs = [r["total_cost_usd"] for r in rows]
+        assert costs == sorted(costs, reverse=True)
+
+    def test_kind_filter_slash(self, db):
+        rows = query_tasks(db, kind="slash")
+        assert all(r["kind"] == "slash" for r in rows)
+        assert len(rows) == 1
+
+    def test_kind_filter_skill(self, db):
+        rows = query_tasks(db, kind="skill")
+        assert all(r["kind"] == "skill" for r in rows)
+        # battle-qa appears across 2 sessions but aggregates into 1 row
+        assert len(rows) == 1
+        assert rows[0]["calls"] == 2
+
+    def test_kind_filter_subagent(self, db):
+        rows = query_tasks(db, kind="subagent")
+        assert len(rows) == 1
+        assert rows[0]["name"] == "implement"
+
+    def test_invalid_kind_returns_empty(self, db):
+        rows = query_tasks(db, kind="unknown_kind")
+        assert rows == []
+
+    def test_limit_respected(self, db):
+        rows = query_tasks(db, limit=1)
+        assert len(rows) == 1
+
+    def test_empty_db(self, db):
+        """Empty spans table returns empty list, not an error."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        init_db(conn)
+        assert query_tasks(conn) == []
+        conn.close()


### PR DESCRIPTION
Implements /api/tasks route (Tasks P1).

- FastAPI GET /api/tasks with optional kind filter (slash|skill|subagent) and limit
- query_tasks() pure function testable without FastAPI
- SQLite spans schema with WAL, kind/name/tokens/cost indexes
- 13 tests: all aggregation, filtering, ordering, edge cases

Closes #29