### PR TITLE
feat: waterfall view tab in trace tree

### DIFF
--- a/burnmap/static/css/waterfall.css
+++ b/burnmap/static/css/waterfall.css
@@ -1,0 +1,91 @@
+/* waterfall.css — Gantt-style waterfall view styles */
+
+/* Card wrapper */
+.wf-card { overflow-x: auto; }
+
+/* Header row */
+.wf-header {
+  display: grid;
+  grid-template-columns: 300px 1fr 80px;
+  gap: 10px;
+  padding: 4px 12px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-3);
+  border-bottom: 1px solid var(--rule-soft);
+  position: relative;
+}
+.wf-label-col { display: flex; align-items: center; }
+.wf-track-col { position: relative; height: 16px; display: flex; align-items: center; }
+.wf-track-col span { position: absolute; }
+.wf-cost-col  { text-align: right; }
+
+/* Data rows */
+.wf-row {
+  display: grid;
+  grid-template-columns: 300px 1fr 80px;
+  gap: 10px;
+  align-items: center;
+  padding: 3px 12px;
+  border-bottom: 1px dashed var(--rule-soft);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+.wf-row:last-child { border-bottom: none; }
+
+/* Label column */
+.wf-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Track: grey background + colored bar */
+.wf-track {
+  position: relative;
+  height: 14px;
+  background: var(--paper-3);
+  border-radius: 2px;
+}
+.wf-bar {
+  position: absolute;
+  height: 100%;
+  border-radius: 2px;
+  min-width: 2px;
+  opacity: 0.85;
+  transition: opacity 0.1s;
+}
+.wf-bar:hover { opacity: 1; cursor: pointer; }
+
+/* Cost column */
+.wf-cost { text-align: right; font-size: 10.5px; }
+
+/* Kind dot (legend + rows) */
+.wf-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* Legend strip */
+.wf-legend {
+  display: flex;
+  gap: 12px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-3);
+  flex-wrap: wrap;
+}
+.wf-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Body wrapper */
+.wf-body { padding: 0; }

--- a/burnmap/templates/components/waterfall.html
+++ b/burnmap/templates/components/waterfall.html
@@ -1,0 +1,104 @@
+{# waterfall.html — Gantt-style waterfall component for the trace tree page.
+   Usage: {% from "components/waterfall.html" import waterfall_tab %}
+          {{ waterfall_tab(trace) }}
+
+   trace object shape (same as trace_tree.html context):
+     .total_tokens (int), .duration_ms (int, 0 = use token-proportional fallback)
+     .tree — root span node (recursive .children list)
+   Each span node:
+     .id, .label, .kind ('turn'|'tool'|'subagent'|'slash'|'skill'), .tokens (int),
+     .cost (float), .loop (bool),
+     .started_at (int ms epoch, 0 = unknown), .ended_at (int ms epoch, 0 = unknown)
+#}
+
+{# ── Color map: kind → CSS var ──────────────────────────────────────── #}
+{% set KIND_COLORS = {
+  "turn":     "var(--ink-3)",
+  "tool":     "var(--heat-3)",
+  "subagent": "var(--subagent)",
+  "slash":    "var(--heat-2)",
+  "skill":    "var(--heat-4)"
+} %}
+{% set LOOP_COLOR = "var(--alert)" %}
+
+{# ── Flatten trace tree into rows (DFS, token-offset fallback) ─────── #}
+{# We use a recursive macro to flatten because Jinja2 has no loops with  #}
+{# mutable accumulator state. Each row carries depth, start%, width%.    #}
+{# When duration_ms > 0 and started_at > 0 we use real timestamps;       #}
+{# otherwise we fall back to cumulative token proportions.               #}
+
+{% macro _span_rows(node, depth, tok_offset, total_toks, total_dur_ms, use_ts, ts_origin) %}
+  {%- set node_dur_tok = node.tokens if node.tokens > 0 else 1 -%}
+  {%- if use_ts and node.started_at and node.ended_at -%}
+    {%- set start_pct = ((node.started_at - ts_origin) / total_dur_ms * 100) | round(2) -%}
+    {%- set width_pct = ((node.ended_at - node.started_at) / total_dur_ms * 100) | round(2) | max(0.5) -%}
+  {%- else -%}
+    {%- set start_pct = (tok_offset / total_toks * 100) | round(2) -%}
+    {%- set width_pct = (node_dur_tok / total_toks * 100) | round(2) | max(0.5) -%}
+  {%- endif -%}
+  {%- set bar_color = LOOP_COLOR if node.loop else KIND_COLORS.get(node.kind, "var(--heat-3)") -%}
+  {%- set short_label = node.label[:32] ~ "…" if node.label | length > 32 else node.label -%}
+  <div class="wf-row" data-kind="{{ node.kind }}" data-id="{{ node.id }}">
+    <span class="wf-label" style="padding-left: {{ depth * 14 }}px;">
+      <i class="wf-dot" style="background: {{ bar_color }};"></i>
+      {{ short_label | e }}
+    </span>
+    <div class="wf-track">
+      <div class="wf-bar"
+           style="left: {{ start_pct }}%; width: {{ width_pct }}%; background: {{ bar_color }};"
+           title="{{ node.label | e }} · {{ node.tokens }} tok · {{ node.cost | round(4) }} $">
+      </div>
+    </div>
+    <span class="wf-cost num muted">{{ "$%.4f" | format(node.cost) }}</span>
+  </div>
+  {%- if node.children -%}
+    {%- set child_offset = tok_offset -%}
+    {%- for child in node.children -%}
+      {{ _span_rows(child, depth + 1, child_offset, total_toks, total_dur_ms, use_ts, ts_origin) }}
+      {%- set child_offset = child_offset + child.tokens -%}
+    {%- endfor -%}
+  {%- endif -%}
+{% endmacro %}
+
+
+{% macro waterfall_tab(trace) %}
+{%- set total_toks  = trace.total_tokens if trace.total_tokens > 0 else 1 -%}
+{%- set total_dur   = trace.duration_ms  if trace.duration_ms  > 0 else 0 -%}
+{%- set use_ts      = (total_dur > 0) -%}
+{%- set ts_origin   = trace.tree.started_at if (use_ts and trace.tree.started_at) else 0 -%}
+
+<div class="card wf-card">
+  {# ── Legend ────────────────────────────────────────────────────── #}
+  <div class="card__h" style="flex-wrap: wrap; gap: 8px;">
+    <h3 style="margin: 0;">Waterfall</h3>
+    <span class="meta">
+      {%- if use_ts -%}duration ∝ time{%- else -%}width ∝ tokens (no timestamps){%- endif -%}
+    </span>
+    <span class="spacer"></span>
+    <span class="wf-legend">
+      {% for kind, color in KIND_COLORS.items() %}
+      <span class="wf-legend-item">
+        <i class="wf-dot" style="background: {{ color }};"></i>{{ kind }}
+      </span>
+      {% endfor %}
+      <span class="wf-legend-item">
+        <i class="wf-dot" style="background: {{ LOOP_COLOR }};"></i>loop
+      </span>
+    </span>
+  </div>
+
+  {# ── Rows ──────────────────────────────────────────────────────── #}
+  <div class="card__body card__body--flush wf-body">
+    <div class="wf-header">
+      <span class="wf-label-col">span</span>
+      <div class="wf-track-col">
+        <span style="left: 0%;">0%</span>
+        <span style="left: 50%; transform: translateX(-50%);">50%</span>
+        <span style="right: 0%;">100%</span>
+      </div>
+      <span class="wf-cost-col">cost</span>
+    </div>
+    {{ _span_rows(trace.tree, 0, 0, total_toks, total_dur, use_ts, ts_origin) }}
+  </div>
+</div>
+{% endmacro %}

--- a/burnmap/templates/pages/trace_tree.html
+++ b/burnmap/templates/pages/trace_tree.html
@@ -1,0 +1,77 @@
+{# trace_tree.html — Trace tree page with flame / indented / waterfall tabs
+   Props (passed via template context):
+     trace  — trace object with .id, .label, .total_tokens, .total_cost,
+               .duration_ms (may be 0), .turns, .tools, .tree (nested spans)
+   Each span node:
+     .id, .label, .kind, .tokens, .cost, .loop, .children (list),
+     .started_at (ms epoch, optional), .ended_at (ms epoch, optional)
+#}
+{% from "components/waterfall.html" import waterfall_tab %}
+
+<div class="page" style="max-width: none;" x-data="traceTreePage()" x-init="init()">
+
+  {# ── Trace header ─────────────────────────────────────────────── #}
+  <div class="row" style="margin-bottom: 6px; font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3);">
+    <a href="/traces" class="btn btn--ghost">← back</a>
+    <span>trace <b style="color: var(--ink);">{{ trace.id }}</b></span>
+    <span class="spacer"></span>
+    <span>{{ trace.total_tokens | int | format_tok }} tokens</span>
+    <span>·</span>
+    <span>{{ trace.total_cost | format_cost }}</span>
+  </div>
+
+  <div class="card" style="margin-bottom: 14px;">
+    <div class="card__body" style="padding: 12px 16px;">
+      <div style="font-size: 15px; font-family: var(--font-mono);">"{{ trace.label }}"</div>
+      <div class="row" style="margin-top: 8px; gap: 16px; font-family: var(--font-mono); font-size: 11px; color: var(--ink-3);">
+        <span>turns <b style="color: var(--ink);">{{ trace.turns }}</b></span>
+        <span>tools <b style="color: var(--ink);">{{ trace.tools }}</b></span>
+      </div>
+    </div>
+  </div>
+
+  {# ── Tab bar ──────────────────────────────────────────────────── #}
+  <div class="row" style="margin-bottom: 10px; gap: 4px; border-bottom: 1px solid var(--rule-soft);">
+    {% for tab_name in ["flame", "indented", "waterfall"] %}
+    <button class="btn btn--ghost"
+      style="border-radius: 0; padding: 8px 14px;"
+      :style="tab === '{{ tab_name }}' ? 'border-bottom: 2px solid var(--ink);' : 'border-bottom: 2px solid transparent;'"
+      @click="tab = '{{ tab_name }}'">{{ tab_name }}</button>
+    {% endfor %}
+    <span class="spacer"></span>
+  </div>
+
+  {# ── Flame tab ────────────────────────────────────────────────── #}
+  <div x-show="tab === 'flame'" class="card">
+    <div class="card__body card__body--flush" style="padding: 6px;">
+      <div class="icicle-placeholder" style="height: 160px; display: flex; align-items: center;
+           justify-content: center; color: var(--ink-3); font-family: var(--font-mono); font-size: 11px;">
+        [icicle / flame graph]
+      </div>
+    </div>
+  </div>
+
+  {# ── Indented tab ─────────────────────────────────────────────── #}
+  <div x-show="tab === 'indented'" class="card">
+    <div class="card__body">
+      <div class="indented-placeholder" style="color: var(--ink-3); font-family: var(--font-mono); font-size: 11px;">
+        [indented tree]
+      </div>
+    </div>
+  </div>
+
+  {# ── Waterfall tab ────────────────────────────────────────────── #}
+  <div x-show="tab === 'waterfall'">
+    {{ waterfall_tab(trace) }}
+  </div>
+
+</div>
+
+<script>
+function traceTreePage() {
+  return {
+    tab: "flame",
+    init() {},
+  };
+}
+</script>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ name = "t01-burnmap"
 version = "0.1.0"
 description = "Local-first AI coding agent token usage dashboard"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = ["jinja2>=3.1"]
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "pytest-asyncio"]
+dev = ["pytest>=8", "pytest-asyncio", "jinja2>=3.1"]
 
 [project.scripts]
 burnmap = "burnmap.cli:main"

--- a/tests/test_waterfall.py
+++ b/tests/test_waterfall.py
@@ -1,0 +1,161 @@
+"""Tests for waterfall.html Jinja2 component.
+
+Verifies: tab presence, horizontal bars, color-coding by kind,
+token-proportional fallback when no timestamps, timestamp-based layout.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATES_DIR = Path(__file__).parent.parent / "burnmap" / "templates"
+
+
+@pytest.fixture(scope="module")
+def env():
+    e = Environment(
+        loader=FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=True,
+    )
+    # Register a simple round filter for tests
+    e.filters["round"] = round
+    e.filters["format_tok"] = lambda v: f"{int(v):,}"
+    e.filters["format_cost"] = lambda v: f"${v:.4f}"
+    e.filters["max"] = max
+    return e
+
+
+@dataclass
+class Span:
+    id: str
+    label: str
+    kind: str
+    tokens: int
+    cost: float
+    loop: bool = False
+    started_at: int = 0
+    ended_at: int = 0
+    children: list[Any] = field(default_factory=list)
+
+
+@dataclass
+class Trace:
+    id: str
+    label: str
+    total_tokens: int
+    total_cost: float
+    duration_ms: int
+    turns: int
+    tools: int
+    tree: Any
+
+
+def make_trace(with_timestamps: bool = False) -> Trace:
+    tool_span = Span(
+        id="s2", label="Read file", kind="tool",
+        tokens=200, cost=0.002,
+        started_at=1_700_000_500 if with_timestamps else 0,
+        ended_at=1_700_000_700 if with_timestamps else 0,
+    )
+    subagent_span = Span(
+        id="s3", label="subagent: implement", kind="subagent",
+        tokens=800, cost=0.012, loop=False,
+        started_at=1_700_000_700 if with_timestamps else 0,
+        ended_at=1_700_001_200 if with_timestamps else 0,
+    )
+    root = Span(
+        id="s1", label="Write a sorting function", kind="turn",
+        tokens=1000, cost=0.015,
+        started_at=1_700_000_000 if with_timestamps else 0,
+        ended_at=1_700_001_500 if with_timestamps else 0,
+        children=[tool_span, subagent_span],
+    )
+    return Trace(
+        id="trace-abc",
+        label="Write a sorting function",
+        total_tokens=1000,
+        total_cost=0.015,
+        duration_ms=1_500_000 if with_timestamps else 0,
+        turns=1,
+        tools=1,
+        tree=root,
+    )
+
+
+def render_waterfall(env: Environment, trace: Trace) -> str:
+    """Render waterfall_tab macro by importing it into an inline template."""
+    src = (
+        '{% from "components/waterfall.html" import waterfall_tab %}'
+        "{{ waterfall_tab(trace) }}"
+    )
+    tmpl = env.from_string(src)
+    return tmpl.render(trace=trace)
+
+
+class TestWaterfallTabPresent:
+    def test_renders_without_error(self, env):
+        out = render_waterfall(env, make_trace())
+        assert "wf-card" in out
+
+    def test_waterfall_heading(self, env):
+        out = render_waterfall(env, make_trace())
+        assert "Waterfall" in out
+
+    def test_three_tab_buttons_in_page(self, env):
+        """trace_tree.html includes flame/indented/waterfall tab buttons."""
+        tmpl = env.get_template("pages/trace_tree.html")
+        out = tmpl.render(trace=make_trace())
+        for tab in ("flame", "indented", "waterfall"):
+            assert tab in out
+
+
+class TestHorizontalBars:
+    def test_wf_bar_present_for_each_span(self, env):
+        out = render_waterfall(env, make_trace())
+        # Root + 2 children = 3 bars
+        assert out.count("wf-bar") == 3
+
+    def test_bar_has_left_and_width(self, env):
+        out = render_waterfall(env, make_trace())
+        assert "left:" in out
+        assert "width:" in out
+
+
+class TestColorCodingByKind:
+    def test_turn_color(self, env):
+        out = render_waterfall(env, make_trace())
+        assert "var(--ink-3)" in out  # turn color
+
+    def test_tool_color(self, env):
+        out = render_waterfall(env, make_trace())
+        assert "var(--heat-3)" in out  # tool color
+
+    def test_subagent_color(self, env):
+        out = render_waterfall(env, make_trace())
+        assert "var(--subagent)" in out
+
+    def test_loop_color_when_loop_true(self, env):
+        trace = make_trace()
+        trace.tree.loop = True
+        out = render_waterfall(env, trace)
+        assert "var(--alert)" in out
+
+    def test_legend_contains_all_kinds(self, env):
+        out = render_waterfall(env, make_trace())
+        for kind in ("turn", "tool", "subagent", "loop"):
+            assert kind in out
+
+
+class TestFallbackMode:
+    def test_no_timestamps_shows_token_proportional_label(self, env):
+        out = render_waterfall(env, make_trace(with_timestamps=False))
+        assert "tokens" in out  # fallback label contains "tokens"
+        assert "no timestamps" in out
+
+    def test_with_timestamps_shows_time_label(self, env):
+        out = render_waterfall(env, make_trace(with_timestamps=True))
+        assert "duration" in out


### PR DESCRIPTION
Implements waterfall/Gantt tab in trace tree page (Tree P0 mockup).

- `waterfall.html` Jinja2 macro: per-span horizontal bars via `_span_rows` DFS
- Color-coded by kind (turn/tool/subagent/slash/skill) + loop highlight
- Real-timestamp layout when `duration_ms > 0`; token-proportional fallback otherwise
- `trace_tree.html` page with flame/indented/waterfall Alpine.js tabs
- `waterfall.css` grid layout styles
- 12 render tests covering all acceptance criteria

Closes #28