### PR TITLE
chore: repo scaffold — pyproject.toml, CLI, empty server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "t01-burnmap"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.111",
+    "uvicorn[standard]>=0.29",
+    "typer>=0.12",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "httpx>=0.27",
+]
+
+[project.scripts]
+t01-burnmap = "t01_burnmap.cli:app"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["t01_burnmap*"]

--- a/t01_burnmap/__init__.py
+++ b/t01_burnmap/__init__.py
@@ -1,0 +1,1 @@
+# t01-burnmap — local-first AI coding agent token usage dashboard

--- a/t01_burnmap/cli.py
+++ b/t01_burnmap/cli.py
@@ -1,0 +1,19 @@
+"""CLI entry point."""
+import typer
+import uvicorn
+
+app = typer.Typer(help="t01-burnmap — token usage dashboard")
+
+
+@app.command()
+def serve(
+    host: str = "0.0.0.0",
+    port: int = 7820,
+    reload: bool = False,
+) -> None:
+    """Start the burnmap API server."""
+    uvicorn.run("t01_burnmap.server:app", host=host, port=port, reload=reload)
+
+
+if __name__ == "__main__":
+    app()

--- a/t01_burnmap/server.py
+++ b/t01_burnmap/server.py
@@ -1,0 +1,9 @@
+"""FastAPI server stub."""
+from fastapi import FastAPI
+
+app = FastAPI(title="t01-burnmap")
+
+
+@app.get("/")
+def root() -> dict:
+    return {"status": "ok", "service": "t01-burnmap"}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,15 @@
+"""Smoke tests for t01-burnmap server."""
+from fastapi.testclient import TestClient
+from t01_burnmap.server import app
+
+client = TestClient(app)
+
+
+def test_root_returns_200() -> None:
+    resp = client.get("/")
+    assert resp.status_code == 200
+
+
+def test_root_returns_ok() -> None:
+    resp = client.get("/")
+    assert resp.json()["status"] == "ok"


### PR DESCRIPTION
Closes #1

## Changes
- `pyproject.toml` with setuptools, requires-python>=3.12
- `t01_burnmap/server.py` — FastAPI stub returning 200 at `/`
- `t01_burnmap/cli.py` — Typer CLI with `serve` command on port 7820
- `tests/test_smoke.py` — smoke tests for root endpoint

## Testing
```
pip install -e .[dev] && pytest tests/
```