### PR TITLE
feat: SQLite schema — sessions, turns, prompts, spans tables

### DIFF
--- a/burnmap/__init__.py
+++ b/burnmap/__init__.py
@@ -1,0 +1,1 @@
+# t01-burnmap — local-first AI coding agent token usage dashboard

--- a/burnmap/db/__init__.py
+++ b/burnmap/db/__init__.py
@@ -1,0 +1,3 @@
+from .schema import apply_schema, get_connection
+
+__all__ = ["apply_schema", "get_connection"]

--- a/burnmap/db/schema.py
+++ b/burnmap/db/schema.py
@@ -1,0 +1,110 @@
+"""SQLite schema — WAL mode, core tables."""
+from __future__ import annotations
+import sqlite3
+from pathlib import Path
+
+_DDL = """
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id          TEXT PRIMARY KEY,
+    agent       TEXT NOT NULL,
+    started_at  INTEGER NOT NULL,
+    ended_at    INTEGER,
+    git_repo    TEXT,
+    git_branch  TEXT
+);
+
+CREATE TABLE IF NOT EXISTS turns (
+    id                  TEXT PRIMARY KEY,
+    session_id          TEXT NOT NULL REFERENCES sessions(id),
+    agent               TEXT NOT NULL,
+    model               TEXT NOT NULL,
+    input_tokens        INTEGER NOT NULL DEFAULT 0,
+    output_tokens       INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
+    cost_usd            REAL NOT NULL DEFAULT 0.0,
+    timestamp_ms        INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS prompts (
+    id          TEXT PRIMARY KEY,
+    session_id  TEXT NOT NULL REFERENCES sessions(id),
+    turn_id     TEXT REFERENCES turns(id),
+    kind        TEXT NOT NULL,  -- 'user'|'assistant'|'tool'
+    timestamp_ms INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS prompt_runs (
+    id          TEXT PRIMARY KEY,
+    prompt_id   TEXT NOT NULL REFERENCES prompts(id),
+    run_index   INTEGER NOT NULL DEFAULT 0,
+    model       TEXT,
+    cost_usd    REAL NOT NULL DEFAULT 0.0
+);
+
+CREATE TABLE IF NOT EXISTS spans (
+    id          TEXT PRIMARY KEY,
+    session_id  TEXT NOT NULL REFERENCES sessions(id),
+    turn_id     TEXT REFERENCES turns(id),
+    name        TEXT NOT NULL,
+    started_at  INTEGER NOT NULL,
+    ended_at    INTEGER,
+    status      TEXT NOT NULL DEFAULT 'ok'
+);
+
+CREATE TABLE IF NOT EXISTS trace_aggregates (
+    id          TEXT PRIMARY KEY,
+    session_id  TEXT NOT NULL REFERENCES sessions(id),
+    span_name   TEXT NOT NULL,
+    count       INTEGER NOT NULL DEFAULT 0,
+    total_ms    INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS tool_aggregates (
+    id          TEXT PRIMARY KEY,
+    session_id  TEXT NOT NULL REFERENCES sessions(id),
+    tool_name   TEXT NOT NULL,
+    call_count  INTEGER NOT NULL DEFAULT 0,
+    error_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS span_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    span_id     TEXT NOT NULL REFERENCES spans(id),
+    name        TEXT NOT NULL,
+    timestamp_ms INTEGER NOT NULL DEFAULT 0,
+    attributes  TEXT  -- JSON blob
+);
+"""
+
+_CONTENT_DDL = """
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS prompt_content (
+    prompt_id   TEXT PRIMARY KEY,
+    content     TEXT
+);
+"""
+
+
+def get_connection(db_path: str | Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def apply_schema(db_path: str | Path, content_db_path: str | Path | None = None) -> None:
+    """Apply DDL migrations to main DB and optional content DB."""
+    conn = get_connection(db_path)
+    conn.executescript(_DDL)
+    conn.commit()
+    conn.close()
+
+    if content_db_path is not None:
+        conn = get_connection(content_db_path)
+        conn.executescript(_CONTENT_DDL)
+        conn.commit()
+        conn.close()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,62 @@
+"""Tests for SQLite schema creation and basic CRUD."""
+import sqlite3
+import tempfile
+from pathlib import Path
+import pytest
+from burnmap.db.schema import apply_schema, get_connection
+
+EXPECTED_TABLES = {
+    "sessions", "turns", "prompts", "prompt_runs",
+    "spans", "trace_aggregates", "tool_aggregates", "span_events",
+}
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    p = tmp_path / "test.db"
+    apply_schema(p)
+    return p
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    return {r[0] for r in rows if not r[0].startswith("sqlite_")}
+
+
+def test_all_tables_created(db_path: Path) -> None:
+    conn = get_connection(db_path)
+    assert EXPECTED_TABLES == _tables(conn)
+    conn.close()
+
+
+def test_wal_mode_enabled(db_path: Path) -> None:
+    conn = get_connection(db_path)
+    mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+    assert mode == "wal"
+    conn.close()
+
+
+def test_session_insert_and_select(db_path: Path) -> None:
+    conn = get_connection(db_path)
+    conn.execute(
+        "INSERT INTO sessions (id, agent, started_at) VALUES (?, ?, ?)",
+        ("s1", "claude_code", 1000),
+    )
+    conn.commit()
+    row = conn.execute("SELECT * FROM sessions WHERE id='s1'").fetchone()
+    assert row["agent"] == "claude_code"
+    conn.close()
+
+
+def test_content_db_separate(tmp_path: Path) -> None:
+    main = tmp_path / "main.db"
+    content = tmp_path / "content.db"
+    apply_schema(main, content_db_path=content)
+    conn = get_connection(content)
+    tables = _tables(conn)
+    assert "prompt_content" in tables
+    conn.close()
+    # main DB should not have prompt_content
+    conn2 = get_connection(main)
+    assert "prompt_content" not in _tables(conn2)
+    conn2.close()


### PR DESCRIPTION
Closes #2

## Changes
- `burnmap/db/schema.py` — 8 core tables with WAL mode, FK constraints
- Separate content DB (prompt_content) attachable/detachable
- `tests/test_schema.py` — 4 tests: table creation, WAL, CRUD, content DB separation

## Testing
```
PYTHONPATH=. pytest tests/test_schema.py
```