### PR TITLE
feat: adapter base class + adapter registry

### DIFF
--- a/t01_burnmap/__init__.py
+++ b/t01_burnmap/__init__.py
@@ -1,0 +1,1 @@
+# t01-burnmap — local-first AI coding agent token usage dashboard

--- a/t01_burnmap/adapters/__init__.py
+++ b/t01_burnmap/adapters/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseAdapter
+from .registry import AdapterRegistry
+
+__all__ = ["BaseAdapter", "AdapterRegistry"]

--- a/t01_burnmap/adapters/base.py
+++ b/t01_burnmap/adapters/base.py
@@ -1,0 +1,21 @@
+"""Base adapter ABC."""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+
+class BaseAdapter(ABC):
+    """Abstract base class for all log-file adapters."""
+
+    @abstractmethod
+    def default_paths(self) -> list[Path]:
+        """Return default log file/directory paths for this adapter."""
+
+    @abstractmethod
+    def is_supported_file(self, path: Path) -> bool:
+        """Return True if this adapter can parse the given file."""
+
+    @abstractmethod
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        """Parse a file and return a list of raw turn records."""

--- a/t01_burnmap/adapters/registry.py
+++ b/t01_burnmap/adapters/registry.py
@@ -1,0 +1,28 @@
+"""Adapter registry — discover and load adapters by name."""
+from __future__ import annotations
+from .base import BaseAdapter
+
+
+class AdapterRegistry:
+    """Registry for BaseAdapter implementations."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, type[BaseAdapter]] = {}
+
+    def register(self, name: str, adapter_cls: type[BaseAdapter]) -> None:
+        """Register an adapter class under a name."""
+        if not issubclass(adapter_cls, BaseAdapter):
+            raise TypeError(f"{adapter_cls} must subclass BaseAdapter")
+        self._adapters[name] = adapter_cls
+
+    def get(self, name: str) -> type[BaseAdapter]:
+        """Return an adapter class by name. Raises KeyError if not found."""
+        return self._adapters[name]
+
+    def all_names(self) -> list[str]:
+        """Return all registered adapter names."""
+        return list(self._adapters.keys())
+
+    def instantiate(self, name: str) -> BaseAdapter:
+        """Instantiate and return an adapter by name."""
+        return self._adapters[name]()

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -1,0 +1,69 @@
+"""Tests for BaseAdapter ABC and AdapterRegistry."""
+from pathlib import Path
+from typing import Any
+import pytest
+from t01_burnmap.adapters import BaseAdapter, AdapterRegistry
+
+
+class MockAdapter(BaseAdapter):
+    def default_paths(self) -> list[Path]:
+        return [Path("/tmp/mock-logs")]
+
+    def is_supported_file(self, path: Path) -> bool:
+        return path.suffix == ".json"
+
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        return [{"mock": True, "path": str(path)}]
+
+
+def test_base_adapter_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        BaseAdapter()  # type: ignore[abstract]
+
+
+def test_mock_adapter_default_paths() -> None:
+    adapter = MockAdapter()
+    assert Path("/tmp/mock-logs") in adapter.default_paths()
+
+
+def test_mock_adapter_is_supported_file() -> None:
+    adapter = MockAdapter()
+    assert adapter.is_supported_file(Path("log.json"))
+    assert not adapter.is_supported_file(Path("log.txt"))
+
+
+def test_mock_adapter_parse_file(tmp_path: Path) -> None:
+    adapter = MockAdapter()
+    result = adapter.parse_file(tmp_path / "log.json")
+    assert result[0]["mock"] is True
+
+
+def test_registry_register_and_get() -> None:
+    reg = AdapterRegistry()
+    reg.register("mock", MockAdapter)
+    assert reg.get("mock") is MockAdapter
+
+
+def test_registry_instantiate() -> None:
+    reg = AdapterRegistry()
+    reg.register("mock", MockAdapter)
+    inst = reg.instantiate("mock")
+    assert isinstance(inst, MockAdapter)
+
+
+def test_registry_all_names() -> None:
+    reg = AdapterRegistry()
+    reg.register("mock", MockAdapter)
+    assert "mock" in reg.all_names()
+
+
+def test_registry_rejects_non_adapter() -> None:
+    reg = AdapterRegistry()
+    with pytest.raises(TypeError):
+        reg.register("bad", object)  # type: ignore[arg-type]
+
+
+def test_registry_raises_on_missing() -> None:
+    reg = AdapterRegistry()
+    with pytest.raises(KeyError):
+        reg.get("nonexistent")


### PR DESCRIPTION
Closes #3

## Changes
- `t01_burnmap/adapters/base.py` — BaseAdapter ABC with default_paths, is_supported_file, parse_file
- `t01_burnmap/adapters/registry.py` — AdapterRegistry with register/get/instantiate/all_names
- `tests/test_adapter_registry.py` — 9 tests with MockAdapter

## Testing
```
PYTHONPATH=. pytest tests/test_adapter_registry.py
```