### PR TITLE
feat: outlier review page — cross-prompt flagged runs

### DIFF
--- a/burnmap/api/outlier_review.py
+++ b/burnmap/api/outlier_review.py
@@ -1,0 +1,108 @@
+"""/api/outliers — cross-prompt flagged runs for the outlier review page."""
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends, Query
+    from fastapi.responses import JSONResponse
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/outliers")
+    def list_outliers(
+        sort: str = Query("sigma", description="Sort field: sigma|cost|tokens|when"),
+        limit: int = Query(200, ge=1, le=1000),
+        db: sqlite3.Connection = Depends(_db),
+    ) -> JSONResponse:
+        rows = query_outliers(db, sort=sort, limit=limit)
+        count = query_outlier_count(db)
+        return JSONResponse({"outliers": rows, "count": count})
+
+    @router.get("/api/outliers/count")
+    def outlier_count(db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
+        return JSONResponse({"count": query_outlier_count(db)})
+else:
+    router = None  # type: ignore[assignment]
+
+
+# ── Pure query functions (testable without FastAPI) ──────────────────────────
+
+_VALID_SORTS = {"sigma", "cost", "tokens", "when"}
+
+
+def query_outliers(
+    conn: sqlite3.Connection,
+    *,
+    sort: str = "sigma",
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    """Return flagged spans with computed sigma value.
+
+    Each row contains:
+      span_id, name, session_id, agent, input_tokens, output_tokens,
+      cost_usd, started_at, mean_cost, sigma
+    """
+    if sort not in _VALID_SORTS:
+        sort = "sigma"
+
+    order_col = {
+        "sigma": "sigma DESC",
+        "cost": "s.cost_usd DESC",
+        "tokens": "(s.input_tokens + s.output_tokens) DESC",
+        "when": "s.started_at DESC",
+    }[sort]
+
+    # Compute per-name mean and stdev inline using a subquery
+    sql = f"""
+        WITH stats AS (
+            SELECT
+                name,
+                AVG(cost_usd)  AS mean_cost,
+                -- population stdev via Var = E[X^2] - E[X]^2
+                SQRT(MAX(0, AVG(cost_usd * cost_usd) - AVG(cost_usd) * AVG(cost_usd))) AS pop_stdev
+            FROM spans
+            GROUP BY name
+        )
+        SELECT
+            s.id            AS span_id,
+            s.name,
+            s.session_id,
+            s.agent,
+            s.input_tokens,
+            s.output_tokens,
+            s.cost_usd,
+            s.started_at,
+            st.mean_cost,
+            CASE WHEN st.pop_stdev > 0
+                 THEN (s.cost_usd - st.mean_cost) / st.pop_stdev
+                 ELSE 0 END AS sigma
+        FROM spans s
+        JOIN stats st ON st.name = s.name
+        WHERE s.is_outlier = 1
+        ORDER BY {order_col}
+        LIMIT ?
+    """
+    cur = conn.execute(sql, [limit])
+    return [dict(row) for row in cur.fetchall()]
+
+
+def query_outlier_count(conn: sqlite3.Connection) -> int:
+    """Return count of currently-flagged outlier spans."""
+    row = conn.execute("SELECT COUNT(*) AS n FROM spans WHERE is_outlier = 1").fetchone()
+    return row["n"] if row else 0

--- a/burnmap/templates/outliers.html
+++ b/burnmap/templates/outliers.html
@@ -1,0 +1,186 @@
+{# outliers.html — cross-prompt flagged runs review page #}
+{% extends "base.html" %}
+
+{% block title %}Outliers — burnmap{% endblock %}
+
+{% block content %}
+<div x-data="outliersPage()" x-init="load()">
+
+  <div class="page-header">
+    <h1 class="page-title">
+      Outliers
+      <span class="nav-badge" x-text="count" x-show="count > 0"></span>
+    </h1>
+    <div class="page-controls">
+      <label class="sort-label">Sort by</label>
+      <select class="sort-select" x-model="sort" @change="load()">
+        <option value="sigma">Sigma (desc)</option>
+        <option value="cost">Cost (desc)</option>
+        <option value="tokens">Tokens (desc)</option>
+        <option value="when">Most recent</option>
+      </select>
+    </div>
+  </div>
+
+  <template x-if="loading">
+    <div class="loading-row">Loading…</div>
+  </template>
+
+  <template x-if="!loading && rows.length === 0">
+    {% from "components/empty_state.html" import empty_state %}
+    {{ empty_state(
+      icon='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg>',
+      title="No outliers detected",
+      msg="Run a sweep to flag runs that exceed 2σ for their prompt fingerprint.",
+      cta_label="Run sweep",
+      cta_href="/internal/sweep"
+    ) }}
+  </template>
+
+  <template x-if="!loading && rows.length > 0">
+    <div class="outlier-table-wrap">
+      <table class="outlier-table">
+        <thead>
+          <tr>
+            <th>Prompt fingerprint</th>
+            <th>Run ID</th>
+            <th class="num-col">Sigma</th>
+            <th class="num-col">Tokens</th>
+            <th class="num-col">Cost</th>
+            <th>When</th>
+            <th>Flag reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="row in rows" :key="row.span_id">
+            <tr class="outlier-row"
+                @click="navigate(row)"
+                style="cursor: pointer;">
+              <td class="fp-cell">
+                <a :href="'/prompts/' + encodeURIComponent(row.name)"
+                   @click.stop
+                   class="fp-link"
+                   x-text="row.name"></a>
+              </td>
+              <td class="id-cell" x-text="row.span_id.slice(0, 8) + '…'"></td>
+              <td class="num-col sigma-cell"
+                  :class="row.sigma >= 3 ? 'sigma-high' : 'sigma-mid'"
+                  x-text="row.sigma.toFixed(2) + 'σ'"></td>
+              <td class="num-col" x-text="(row.input_tokens + row.output_tokens).toLocaleString()"></td>
+              <td class="num-col" x-text="'$' + row.cost_usd.toFixed(4)"></td>
+              <td x-text="fmtTime(row.started_at)"></td>
+              <td class="reason-cell">
+                <span class="reason-badge"
+                      x-text="'>' + row.sigma.toFixed(1) + 'σ above mean ($' + row.mean_cost.toFixed(4) + ')'"></span>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+  </template>
+
+</div>
+
+<style>
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+.page-title {
+  font-size: 20px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.nav-badge {
+  background: var(--accent, #e65c00);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 10px;
+  min-width: 18px;
+  text-align: center;
+}
+.page-controls { display: flex; align-items: center; gap: 8px; }
+.sort-label { font-size: 12px; color: var(--ink-3, #888); }
+.sort-select { font-size: 13px; padding: 4px 8px; border: 1px solid var(--rule-soft, #ddd); border-radius: 4px; }
+.loading-row { padding: 40px; text-align: center; color: var(--ink-3, #888); font-size: 14px; }
+.outlier-table-wrap { overflow-x: auto; }
+.outlier-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  font-family: var(--font-mono, monospace);
+}
+.outlier-table th {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 2px solid var(--rule-soft, #ddd);
+  font-size: 11px;
+  color: var(--ink-3, #888);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.outlier-table td { padding: 6px 10px; border-bottom: 1px solid var(--rule-soft, #eee); }
+.outlier-row:hover { background: var(--paper-2, #f5f5f5); }
+.num-col { text-align: right; }
+.fp-cell { max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fp-link { color: var(--accent, #0070f3); text-decoration: none; }
+.fp-link:hover { text-decoration: underline; }
+.id-cell { color: var(--ink-3, #888); }
+.sigma-cell { font-weight: 700; }
+.sigma-high { color: #c0392b; }
+.sigma-mid  { color: #e67e22; }
+.reason-cell { max-width: 220px; }
+.reason-badge {
+  display: inline-block;
+  background: #fff3cd;
+  color: #7d5c00;
+  border: 1px solid #ffd666;
+  border-radius: 3px;
+  padding: 1px 6px;
+  font-size: 11px;
+  white-space: nowrap;
+}
+</style>
+
+<script>
+function outliersPage() {
+  return {
+    rows: [],
+    count: 0,
+    sort: 'sigma',
+    loading: false,
+
+    async load() {
+      this.loading = true;
+      try {
+        const r = await fetch('/api/outliers?sort=' + this.sort + '&limit=200');
+        const data = await r.json();
+        this.rows = data.outliers || [];
+        this.count = data.count || 0;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    navigate(row) {
+      window.location.href = '/prompts/' + encodeURIComponent(row.name);
+    },
+
+    fmtTime(ms) {
+      if (!ms) return '—';
+      return new Date(ms).toLocaleString(undefined, {
+        month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit'
+      });
+    },
+  };
+}
+</script>
+{% endblock %}

--- a/tests/test_outlier_review.py
+++ b/tests/test_outlier_review.py
@@ -1,0 +1,110 @@
+"""Tests for the outlier review page API — query_outliers and query_outlier_count."""
+from __future__ import annotations
+
+import sqlite3
+import uuid
+
+import pytest
+
+from burnmap.api.outlier_review import query_outlier_count, query_outliers
+from burnmap.db.schema import init_db
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    db = sqlite3.connect(str(tmp_path / "test.db"))
+    db.row_factory = sqlite3.Row
+    # Add is_outlier column (from PR#39 schema)
+    db.executescript("""
+        CREATE TABLE spans (
+            id            TEXT PRIMARY KEY,
+            session_id    TEXT NOT NULL DEFAULT 'sess',
+            agent         TEXT NOT NULL DEFAULT 'claude_code',
+            kind          TEXT NOT NULL DEFAULT 'turn',
+            name          TEXT NOT NULL,
+            input_tokens  INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cost_usd      REAL DEFAULT 0.0,
+            started_at    INTEGER DEFAULT 0,
+            is_outlier    INTEGER DEFAULT 0
+        );
+    """)
+    return db
+
+
+def _insert(conn, name, cost, is_outlier=0, input_tok=100, output_tok=50, started_at=0):
+    sid = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO spans VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (sid, "sess1", "claude_code", "turn", name, input_tok, output_tok, cost, started_at, is_outlier),
+    )
+    conn.commit()
+    return sid
+
+
+def test_count_empty(conn):
+    assert query_outlier_count(conn) == 0
+
+
+def test_count_with_outliers(conn):
+    _insert(conn, "foo", 1.0, is_outlier=1)
+    _insert(conn, "bar", 2.0, is_outlier=1)
+    _insert(conn, "baz", 0.5, is_outlier=0)
+    assert query_outlier_count(conn) == 2
+
+
+def test_query_outliers_returns_only_flagged(conn):
+    _insert(conn, "skill:foo", 1.0, is_outlier=0)
+    oid = _insert(conn, "skill:foo", 20.0, is_outlier=1)
+    rows = query_outliers(conn)
+    assert len(rows) == 1
+    assert rows[0]["span_id"] == oid
+    assert rows[0]["name"] == "skill:foo"
+
+
+def test_query_outliers_includes_sigma(conn):
+    # Insert 4 normal + 1 outlier for skill:bar
+    for _ in range(4):
+        _insert(conn, "skill:bar", 1.0, is_outlier=0)
+    _insert(conn, "skill:bar", 10.0, is_outlier=1)
+    rows = query_outliers(conn)
+    assert len(rows) == 1
+    assert rows[0]["sigma"] > 0
+
+
+def test_query_outliers_sort_cost(conn):
+    _insert(conn, "a", 5.0, is_outlier=1)
+    _insert(conn, "b", 2.0, is_outlier=1)
+    _insert(conn, "c", 8.0, is_outlier=1)
+    rows = query_outliers(conn, sort="cost")
+    costs = [r["cost_usd"] for r in rows]
+    assert costs == sorted(costs, reverse=True)
+
+
+def test_query_outliers_sort_tokens(conn):
+    _insert(conn, "a", 1.0, is_outlier=1, input_tok=50, output_tok=50)
+    _insert(conn, "b", 1.0, is_outlier=1, input_tok=200, output_tok=100)
+    rows = query_outliers(conn, sort="tokens")
+    totals = [r["input_tokens"] + r["output_tokens"] for r in rows]
+    assert totals == sorted(totals, reverse=True)
+
+
+def test_query_outliers_sort_when(conn):
+    _insert(conn, "a", 1.0, is_outlier=1, started_at=1000)
+    _insert(conn, "b", 1.0, is_outlier=1, started_at=3000)
+    rows = query_outliers(conn, sort="when")
+    times = [r["started_at"] for r in rows]
+    assert times == sorted(times, reverse=True)
+
+
+def test_query_outliers_invalid_sort_defaults_to_sigma(conn):
+    _insert(conn, "a", 1.0, is_outlier=1)
+    rows = query_outliers(conn, sort="invalid_field")
+    assert isinstance(rows, list)
+
+
+def test_query_outliers_limit(conn):
+    for i in range(10):
+        _insert(conn, f"fp{i}", float(i + 1), is_outlier=1)
+    rows = query_outliers(conn, limit=3)
+    assert len(rows) <= 3


### PR DESCRIPTION
## Summary

Implements #26 — cross-prompt outlier review page.

- `/api/outliers` endpoint: returns flagged spans with computed sigma, sortable by sigma/cost/tokens/when
- `/api/outliers/count` endpoint: count for nav rail badge
- `burnmap/templates/outliers.html`: Alpine.js table with sort dropdown, sigma colour-coding, click-through to prompt detail
- 9 unit tests covering count, filtering, all sort modes, limit, invalid sort fallback

Closes #26

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>