### PR TITLE
feat: loop-collapse rule + stuck-loop detection

### DIFF
--- a/burnmap/api/alerts.py
+++ b/burnmap/api/alerts.py
@@ -1,0 +1,84 @@
+"""/api/alerts — stuck-loop SSE stream and alert page data."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends
+    from fastapi.responses import JSONResponse, StreamingResponse
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+from burnmap.loop_detect import collapse_loops, detect_stuck_loops
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/alerts/stuck-loops")
+    def stuck_loops(db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
+        """Return all currently-detected stuck loops from the span table."""
+        rows = query_recent_spans(db)
+        alerts = detect_stuck_loops(rows)
+        return JSONResponse({"alerts": [a.to_dict() for a in alerts]})
+
+    @router.get("/api/alerts/loop-tree")
+    def loop_tree(db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
+        """Return the collapsed span tree for the alert page."""
+        rows = query_recent_spans(db)
+        collapsed = collapse_loops(rows)
+        return JSONResponse({
+            "tree": [
+                s.to_dict() if hasattr(s, "to_dict") else s
+                for s in collapsed
+            ]
+        })
+
+    @router.get("/api/alerts/sse")
+    def stuck_loop_sse(db: sqlite3.Connection = Depends(_db)) -> StreamingResponse:
+        """SSE stream: emits stuck_loop events for any active stuck loops."""
+        def _generate():
+            rows = query_recent_spans(db)
+            alerts = detect_stuck_loops(rows)
+            if alerts:
+                for alert in alerts:
+                    data = json.dumps(alert.to_dict())
+                    yield f"data: {data}\n\n"
+            else:
+                yield "data: {\"event\": \"no_stuck_loops\"}\n\n"
+
+        return StreamingResponse(
+            _generate(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+else:
+    router = None  # type: ignore[assignment]
+
+
+# ── Pure data helpers ─────────────────────────────────────────────────────────
+
+def query_recent_spans(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = 500,
+) -> list[dict[str, Any]]:
+    """Fetch recent spans ordered by started_at for loop analysis."""
+    cur = conn.execute(
+        "SELECT id, session_id, agent, kind, name, input_tokens, output_tokens, "
+        "cost_usd, started_at FROM spans ORDER BY started_at DESC LIMIT ?",
+        [limit],
+    )
+    return [dict(row) for row in cur.fetchall()]

--- a/burnmap/loop_detect.py
+++ b/burnmap/loop_detect.py
@@ -1,0 +1,158 @@
+"""Loop-collapse rule and stuck-loop detection for span trees.
+
+Loop-collapse: >= 4 consecutive identical tool siblings are grouped into a
+LoopBlock with count/mean/stdev/min/max stats.
+
+Stuck-loop: flag when a loop has >= 20 iterations OR cost is trending up.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ── Data structures ──────────────────────────────────────────────────────────
+
+@dataclass
+class LoopBlock:
+    """Collapsed representation of >= 4 identical consecutive tool spans."""
+    name: str
+    count: int
+    costs: list[float]
+
+    @property
+    def mean(self) -> float:
+        return sum(self.costs) / len(self.costs) if self.costs else 0.0
+
+    @property
+    def stdev(self) -> float:
+        n = len(self.costs)
+        if n < 2:
+            return 0.0
+        mean = self.mean
+        return math.sqrt(sum((c - mean) ** 2 for c in self.costs) / n)
+
+    @property
+    def min_cost(self) -> float:
+        return min(self.costs) if self.costs else 0.0
+
+    @property
+    def max_cost(self) -> float:
+        return max(self.costs) if self.costs else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": "loop_block",
+            "name": self.name,
+            "count": self.count,
+            "mean_cost": round(self.mean, 6),
+            "stdev_cost": round(self.stdev, 6),
+            "min_cost": round(self.min_cost, 6),
+            "max_cost": round(self.max_cost, 6),
+            "total_cost": round(sum(self.costs), 6),
+        }
+
+
+@dataclass
+class StuckLoopAlert:
+    """Alert emitted when a loop is detected as stuck."""
+    name: str
+    count: int
+    reason: str           # "iteration_count" | "cost_trending_up"
+    costs: list[float] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event": "stuck_loop",
+            "name": self.name,
+            "count": self.count,
+            "reason": self.reason,
+            "costs": [round(c, 6) for c in self.costs],
+        }
+
+
+# ── Loop-collapse ─────────────────────────────────────────────────────────────
+
+def collapse_loops(
+    spans: list[dict[str, Any]],
+    *,
+    min_run: int = 4,
+) -> list[Any]:
+    """Collapse consecutive identical-name tool siblings into LoopBlock entries.
+
+    Non-loop spans are returned as-is. Returns a mixed list of raw span dicts
+    and LoopBlock instances.
+    """
+    if not spans:
+        return []
+
+    result: list[Any] = []
+    i = 0
+    while i < len(spans):
+        name = spans[i].get("name", "")
+        # Count consecutive run
+        j = i + 1
+        while j < len(spans) and spans[j].get("name", "") == name:
+            j += 1
+        run_len = j - i
+        if run_len >= min_run:
+            costs = [float(s.get("cost_usd", 0.0)) for s in spans[i:j]]
+            result.append(LoopBlock(name=name, count=run_len, costs=costs))
+        else:
+            result.extend(spans[i:j])
+        i = j
+    return result
+
+
+# ── Stuck-loop detection ──────────────────────────────────────────────────────
+
+def _is_trending_up(costs: list[float]) -> bool:
+    """Return True if costs have a positive linear trend (slope > 0)."""
+    n = len(costs)
+    if n < 3:
+        return False
+    xs = list(range(n))
+    mean_x = sum(xs) / n
+    mean_y = sum(costs) / n
+    num = sum((xs[i] - mean_x) * (costs[i] - mean_y) for i in range(n))
+    den = sum((xs[i] - mean_x) ** 2 for i in range(n))
+    if den == 0:
+        return False
+    return (num / den) > 0
+
+
+def detect_stuck_loops(
+    spans: list[dict[str, Any]],
+    *,
+    min_run: int = 4,
+    stuck_threshold: int = 20,
+) -> list[StuckLoopAlert]:
+    """Return StuckLoopAlert for any loop that is stuck.
+
+    A loop is stuck when:
+    - Its consecutive run length >= stuck_threshold, OR
+    - It has >= min_run iterations AND cost is trending up.
+    """
+    alerts: list[StuckLoopAlert] = []
+    i = 0
+    while i < len(spans):
+        name = spans[i].get("name", "")
+        j = i + 1
+        while j < len(spans) and spans[j].get("name", "") == name:
+            j += 1
+        run_len = j - i
+        if run_len >= min_run:
+            costs = [float(s.get("cost_usd", 0.0)) for s in spans[i:j]]
+            if run_len >= stuck_threshold:
+                alerts.append(StuckLoopAlert(
+                    name=name, count=run_len,
+                    reason="iteration_count", costs=costs,
+                ))
+            elif _is_trending_up(costs):
+                alerts.append(StuckLoopAlert(
+                    name=name, count=run_len,
+                    reason="cost_trending_up", costs=costs,
+                ))
+        i = j
+    return alerts

--- a/burnmap/templates/alerts.html
+++ b/burnmap/templates/alerts.html
@@ -1,0 +1,200 @@
+{# alerts.html — stuck-loop alert page: live trace + iteration chart + why-flagged panel #}
+{% extends "base.html" %}
+
+{% block title %}Alerts — burnmap{% endblock %}
+
+{% block content %}
+<div x-data="alertsPage()" x-init="load()">
+
+  <div class="page-header">
+    <h1 class="page-title">
+      Loop Alerts
+      <span class="nav-badge" x-text="alerts.length" x-show="alerts.length > 0"></span>
+    </h1>
+    <button class="btn-sm" @click="load()">Refresh</button>
+  </div>
+
+  <template x-if="loading">
+    <div class="loading-row">Checking for stuck loops…</div>
+  </template>
+
+  <template x-if="!loading && alerts.length === 0">
+    {% from "components/empty_state.html" import empty_state %}
+    {{ empty_state(
+      icon='<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"/><path d="M12 8v4m0 4h.01"/></svg>',
+      title="No stuck loops",
+      msg="No loops are currently flagged. Loops with ≥ 20 iterations or rising cost will appear here.",
+      cta_label=none,
+      cta_href=none
+    ) }}
+  </template>
+
+  <template x-if="!loading && alerts.length > 0">
+    <div class="alerts-layout">
+      <!-- Alert list -->
+      <div class="alert-list">
+        <template x-for="(alert, idx) in alerts" :key="idx">
+          <div class="alert-card"
+               :class="selected === idx ? 'alert-card--active' : ''"
+               @click="select(idx)">
+            <div class="alert-card__name" x-text="alert.name"></div>
+            <div class="alert-card__meta">
+              <span class="alert-badge"
+                    :class="alert.reason === 'iteration_count' ? 'badge-red' : 'badge-orange'"
+                    x-text="alert.reason === 'iteration_count'
+                      ? alert.count + ' iterations'
+                      : 'cost trending up (' + alert.count + ' iters)'"></span>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- Detail panel -->
+      <div class="alert-detail" x-show="selected !== null">
+        <template x-if="selected !== null">
+          <div>
+            <!-- Why flagged -->
+            <div class="detail-section">
+              <div class="detail-section__title">Why flagged</div>
+              <div class="why-panel">
+                <template x-if="currentAlert().reason === 'iteration_count'">
+                  <span>Loop ran <strong x-text="currentAlert().count"></strong> times
+                    — exceeds the stuck-loop threshold of 20.</span>
+                </template>
+                <template x-if="currentAlert().reason === 'cost_trending_up'">
+                  <span>Cost per iteration is increasing across
+                    <strong x-text="currentAlert().count"></strong> runs,
+                    indicating a diverging loop.</span>
+                </template>
+              </div>
+            </div>
+
+            <!-- Live trace (costs list) -->
+            <div class="detail-section">
+              <div class="detail-section__title">Live trace</div>
+              <div class="trace-scroll">
+                <template x-for="(cost, i) in currentAlert().costs" :key="i">
+                  <div class="trace-row">
+                    <span class="trace-idx" x-text="'#' + (i+1)"></span>
+                    <span class="trace-cost" x-text="'$' + cost.toFixed(5)"></span>
+                    <div class="trace-bar-wrap">
+                      <div class="trace-bar"
+                           :style="'width:' + barPct(cost, currentAlert().costs) + '%'"></div>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </div>
+
+            <!-- Iteration chart (mini sparkline via inline SVG) -->
+            <div class="detail-section">
+              <div class="detail-section__title">Iteration cost chart</div>
+              <svg class="spark-svg" :viewBox="sparkViewBox(currentAlert().costs)"
+                   preserveAspectRatio="none">
+                <polyline :points="sparkPoints(currentAlert().costs)"
+                          fill="none" stroke="#e65c00" stroke-width="1.5"/>
+              </svg>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+  </template>
+
+</div>
+
+<style>
+.page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; }
+.page-title { font-size: 20px; font-weight: 600; display: flex; align-items: center; gap: 8px; }
+.nav-badge { background: var(--accent, #e65c00); color: #fff; font-size: 11px; font-weight: 700; padding: 1px 6px; border-radius: 10px; min-width: 18px; text-align: center; }
+.btn-sm { font-size: 12px; padding: 4px 10px; border: 1px solid var(--rule-soft, #ddd); border-radius: 4px; cursor: pointer; background: none; }
+.loading-row { padding: 40px; text-align: center; color: var(--ink-3, #888); font-size: 14px; }
+
+.alerts-layout { display: grid; grid-template-columns: 280px 1fr; gap: 16px; }
+.alert-list { display: flex; flex-direction: column; gap: 8px; }
+.alert-card { border: 1px solid var(--rule-soft, #ddd); border-radius: 6px; padding: 10px 12px; cursor: pointer; }
+.alert-card:hover { background: var(--paper-2, #f5f5f5); }
+.alert-card--active { border-color: var(--accent, #e65c00); background: var(--paper-2, #f5f5f5); }
+.alert-card__name { font-family: var(--font-mono, monospace); font-size: 12px; font-weight: 600; margin-bottom: 4px; word-break: break-all; }
+.alert-badge { font-size: 11px; padding: 2px 6px; border-radius: 3px; font-weight: 600; }
+.badge-red { background: #fde8e8; color: #c0392b; }
+.badge-orange { background: #fff3cd; color: #7d5c00; }
+
+.alert-detail { border: 1px solid var(--rule-soft, #ddd); border-radius: 6px; padding: 16px; }
+.detail-section { margin-bottom: 20px; }
+.detail-section__title { font-size: 11px; font-weight: 700; color: var(--ink-3, #888); text-transform: uppercase; letter-spacing: .05em; margin-bottom: 8px; }
+.why-panel { font-size: 13px; line-height: 1.5; }
+
+.trace-scroll { max-height: 200px; overflow-y: auto; }
+.trace-row { display: grid; grid-template-columns: 32px 70px 1fr; gap: 8px; align-items: center; padding: 2px 0; font-family: var(--font-mono, monospace); font-size: 11px; }
+.trace-idx { color: var(--ink-3, #888); }
+.trace-cost { text-align: right; }
+.trace-bar-wrap { background: var(--paper-3, #eee); border-radius: 2px; height: 8px; }
+.trace-bar { height: 100%; background: var(--accent, #e65c00); border-radius: 2px; min-width: 2px; }
+
+.spark-svg { width: 100%; height: 80px; display: block; border: 1px solid var(--rule-soft, #eee); border-radius: 4px; }
+</style>
+
+<script>
+function alertsPage() {
+  return {
+    alerts: [],
+    selected: null,
+    loading: false,
+
+    async load() {
+      this.loading = true;
+      try {
+        const r = await fetch('/api/alerts/stuck-loops');
+        const data = await r.json();
+        this.alerts = data.alerts || [];
+        if (this.alerts.length > 0) this.selected = 0;
+        else this.selected = null;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    select(idx) { this.selected = idx; },
+
+    currentAlert() {
+      return this.selected !== null ? this.alerts[this.selected] : null;
+    },
+
+    barPct(cost, costs) {
+      const mx = Math.max(...costs);
+      return mx > 0 ? Math.round((cost / mx) * 100) : 0;
+    },
+
+    sparkPoints(costs) {
+      if (!costs || costs.length < 2) return '';
+      const W = 400, H = 60, pad = 4;
+      const mn = Math.min(...costs), mx = Math.max(...costs);
+      const range = mx - mn || 1;
+      return costs.map((c, i) => {
+        const x = pad + (i / (costs.length - 1)) * (W - pad * 2);
+        const y = H - pad - ((c - mn) / range) * (H - pad * 2);
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      }).join(' ');
+    },
+
+    sparkViewBox(costs) {
+      return '0 0 400 60';
+    },
+  };
+}
+
+// SSE subscription for live stuck-loop events
+(function() {
+  const es = new EventSource('/api/alerts/sse');
+  es.onmessage = function(e) {
+    const data = JSON.parse(e.data);
+    if (data.event === 'stuck_loop') {
+      // Trigger a page reload if new stuck loops are detected
+      window.dispatchEvent(new CustomEvent('stuck-loop-detected', { detail: data }));
+    }
+  };
+  es.onerror = function() { es.close(); };
+})();
+</script>
+{% endblock %}

--- a/tests/test_loop_detect.py
+++ b/tests/test_loop_detect.py
@@ -1,0 +1,145 @@
+"""Tests for loop_detect — collapse_loops and detect_stuck_loops."""
+from __future__ import annotations
+
+import pytest
+
+from burnmap.loop_detect import (
+    LoopBlock,
+    StuckLoopAlert,
+    collapse_loops,
+    detect_stuck_loops,
+)
+
+
+def _span(name, cost=0.01):
+    return {"name": name, "cost_usd": cost}
+
+
+# ── collapse_loops ────────────────────────────────────────────────────────────
+
+def test_collapse_empty():
+    assert collapse_loops([]) == []
+
+
+def test_no_collapse_short_run():
+    spans = [_span("tool:a")] * 3
+    result = collapse_loops(spans)
+    # run < 4 → returned as-is
+    assert len(result) == 3
+    assert all(isinstance(s, dict) for s in result)
+
+
+def test_collapse_exact_threshold():
+    spans = [_span("tool:a")] * 4
+    result = collapse_loops(spans)
+    assert len(result) == 1
+    assert isinstance(result[0], LoopBlock)
+    assert result[0].count == 4
+    assert result[0].name == "tool:a"
+
+
+def test_collapse_longer_run():
+    spans = [_span("tool:b", cost=0.05)] * 7
+    result = collapse_loops(spans)
+    assert len(result) == 1
+    lb = result[0]
+    assert lb.count == 7
+    assert abs(lb.mean - 0.05) < 1e-9
+    assert lb.stdev == 0.0
+
+
+def test_collapse_mixed():
+    spans = (
+        [_span("tool:x")] * 2    # < 4, no collapse
+        + [_span("tool:y")] * 5  # >= 4, collapse
+        + [_span("tool:z")]      # single, no collapse
+    )
+    result = collapse_loops(spans)
+    assert len(result) == 4  # 2 + 1 block + 1
+    assert isinstance(result[2], LoopBlock)
+    assert result[2].name == "tool:y"
+    assert result[2].count == 5
+
+
+def test_loop_block_stats():
+    lb = LoopBlock(name="foo", count=3, costs=[1.0, 2.0, 3.0])
+    assert lb.mean == 2.0
+    assert abs(lb.stdev - 0.8164965809) < 1e-6
+    assert lb.min_cost == 1.0
+    assert lb.max_cost == 3.0
+
+
+def test_loop_block_to_dict():
+    lb = LoopBlock(name="foo", count=2, costs=[1.0, 3.0])
+    d = lb.to_dict()
+    assert d["type"] == "loop_block"
+    assert d["count"] == 2
+    assert "mean_cost" in d and "stdev_cost" in d
+
+
+# ── detect_stuck_loops ────────────────────────────────────────────────────────
+
+def test_no_stuck_loops_empty():
+    assert detect_stuck_loops([]) == []
+
+
+def test_no_stuck_loops_short():
+    spans = [_span("tool:a")] * 3
+    assert detect_stuck_loops(spans) == []
+
+
+def test_stuck_loop_by_count():
+    spans = [_span("tool:a")] * 20
+    alerts = detect_stuck_loops(spans, stuck_threshold=20)
+    assert len(alerts) == 1
+    assert alerts[0].reason == "iteration_count"
+    assert alerts[0].count == 20
+
+
+def test_stuck_loop_by_count_exceeds():
+    spans = [_span("tool:a")] * 25
+    alerts = detect_stuck_loops(spans, stuck_threshold=20)
+    assert len(alerts) == 1
+    assert alerts[0].count == 25
+
+
+def test_stuck_loop_trending_up():
+    # 6 iterations with clearly rising cost
+    spans = [_span("tool:b", cost=float(i)) for i in range(1, 7)]
+    alerts = detect_stuck_loops(spans, min_run=4, stuck_threshold=20)
+    assert len(alerts) == 1
+    assert alerts[0].reason == "cost_trending_up"
+
+
+def test_not_stuck_flat_cost():
+    spans = [_span("tool:c", cost=1.0)] * 6
+    alerts = detect_stuck_loops(spans, min_run=4, stuck_threshold=20)
+    # flat cost, count < 20 → not stuck
+    assert alerts == []
+
+
+def test_not_stuck_trending_down():
+    spans = [_span("tool:d", cost=float(6 - i)) for i in range(6)]
+    alerts = detect_stuck_loops(spans, min_run=4, stuck_threshold=20)
+    assert alerts == []
+
+
+def test_stuck_loop_to_dict():
+    alert = StuckLoopAlert(name="x", count=5, reason="cost_trending_up", costs=[1.0, 2.0])
+    d = alert.to_dict()
+    assert d["event"] == "stuck_loop"
+    assert d["reason"] == "cost_trending_up"
+    assert d["costs"] == [1.0, 2.0]
+
+
+def test_multiple_stuck_loops():
+    spans = (
+        [_span("tool:a")] * 20
+        + [_span("tool:b")] * 5  # not stuck (flat, < 20)
+        + [_span("tool:c")] * 20
+    )
+    alerts = detect_stuck_loops(spans, stuck_threshold=20)
+    names = [a.name for a in alerts]
+    assert "tool:a" in names
+    assert "tool:c" in names
+    assert "tool:b" not in names


### PR DESCRIPTION
## Summary

Implements #25 — loop-collapse rule + stuck-loop detection.

- `burnmap/loop_detect.py`: `collapse_loops()` (≥4 consecutive identical siblings → LoopBlock with count/mean/stdev/min/max), `detect_stuck_loops()` (flags at ≥20 iterations or cost trending up, configurable thresholds)
- `burnmap/api/alerts.py`: `/api/alerts/stuck-loops`, `/api/alerts/loop-tree`, `/api/alerts/sse` (SSE stream for live stuck-loop events)
- `burnmap/templates/alerts.html`: Alpine.js alert page with live trace, iteration cost sparkline chart, why-flagged panel
- 16 unit tests covering all collapse and detection paths

Closes #25

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>