### PR TITLE
feat: onboarding page — adapter discovery + backfill progress

### DIFF
--- a/burnmap/api/onboarding.py
+++ b/burnmap/api/onboarding.py
@@ -1,0 +1,111 @@
+"""/api/onboarding — adapter discovery status and backfill progress."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends
+    from fastapi.responses import JSONResponse
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/onboarding/adapters")
+    def adapter_status() -> JSONResponse:
+        """Return discovery status per agent adapter."""
+        return JSONResponse({"adapters": discover_adapters()})
+
+    @router.get("/api/onboarding/backfill")
+    def backfill_progress(db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
+        """Return backfill progress: sessions ingested and estimated remaining."""
+        return JSONResponse(query_backfill_progress(db))
+else:
+    router = None  # type: ignore[assignment]
+
+
+# ── Adapter discovery ─────────────────────────────────────────────────────────
+
+# Known agents and their default log path patterns
+_AGENT_PATHS: dict[str, list[str]] = {
+    "claude_code": [
+        str(Path.home() / ".claude" / "projects"),
+        str(Path.home() / "Library" / "Application Support" / "Claude"),
+    ],
+    "codex": [
+        str(Path.home() / ".codex"),
+        str(Path.home() / ".local" / "share" / "codex"),
+    ],
+    "cline": [
+        str(Path.home() / ".cline"),
+        str(Path.home() / "Library" / "Application Support" / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"),
+    ],
+    "aider": [
+        str(Path.home() / ".aider"),
+        str(Path.home() / ".local" / "share" / "aider"),
+    ],
+}
+
+
+def discover_adapters() -> list[dict[str, Any]]:
+    """Return per-agent discovery status."""
+    result = []
+    for agent, paths in _AGENT_PATHS.items():
+        found_path = None
+        for p in paths:
+            if os.path.exists(p):
+                found_path = p
+                break
+        result.append({
+            "agent": agent,
+            "found": found_path is not None,
+            "path": found_path,
+            "checked_paths": paths,
+        })
+    return result
+
+
+# ── Backfill progress ─────────────────────────────────────────────────────────
+
+def query_backfill_progress(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Return ingested session count and a simple ETA estimate."""
+    row = conn.execute(
+        "SELECT COUNT(DISTINCT session_id) AS sessions, COUNT(*) AS spans FROM spans"
+    ).fetchone()
+    sessions = row["sessions"] if row else 0
+    spans = row["spans"] if row else 0
+
+    # Discover how many log files exist across all known adapter paths
+    total_files = 0
+    for paths in _AGENT_PATHS.values():
+        for p in paths:
+            if os.path.isdir(p):
+                for root, _dirs, files in os.walk(p):
+                    total_files += sum(
+                        1 for f in files
+                        if f.endswith((".json", ".jsonl", ".md", ".log"))
+                    )
+
+    pct = min(100, round((sessions / max(total_files, 1)) * 100)) if total_files else 100
+    return {
+        "sessions_ingested": sessions,
+        "spans_ingested": spans,
+        "log_files_found": total_files,
+        "percent_complete": pct,
+        "complete": pct >= 100,
+    }

--- a/burnmap/templates/onboarding.html
+++ b/burnmap/templates/onboarding.html
@@ -1,0 +1,160 @@
+{# onboarding.html — first-run onboarding: adapter checklist + backfill progress #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Setup — burnmap</title>
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f7f8fa;
+      color: #1a1a1a;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .card {
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 4px 24px rgba(0,0,0,.08);
+      padding: 40px 48px;
+      width: 100%;
+      max-width: 520px;
+    }
+    .logo { font-size: 22px; font-weight: 700; color: #e65c00; margin-bottom: 6px; }
+    .tagline { font-size: 13px; color: #888; margin-bottom: 32px; }
+    h2 { font-size: 16px; font-weight: 600; margin: 0 0 16px; }
+
+    /* Adapter list */
+    .adapter-list { list-style: none; margin: 0 0 28px; padding: 0; }
+    .adapter-item {
+      display: flex; align-items: center; gap: 10px;
+      padding: 8px 0;
+      border-bottom: 1px solid #f0f0f0;
+      font-size: 13px;
+    }
+    .adapter-item:last-child { border-bottom: none; }
+    .adapter-dot {
+      width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
+    }
+    .dot-found { background: #27ae60; }
+    .dot-missing { background: #ccc; }
+    .adapter-name { font-weight: 600; flex: 1; }
+    .adapter-path { font-size: 11px; color: #888; font-family: monospace; max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .badge-found { font-size: 10px; background: #e8f8ef; color: #27ae60; padding: 2px 6px; border-radius: 3px; font-weight: 600; }
+    .badge-missing { font-size: 10px; background: #f5f5f5; color: #999; padding: 2px 6px; border-radius: 3px; }
+
+    /* Progress bar */
+    .progress-section { margin-bottom: 28px; }
+    .progress-header { display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 8px; }
+    .progress-track { background: #f0f0f0; border-radius: 6px; height: 10px; overflow: hidden; }
+    .progress-fill { height: 100%; background: #e65c00; border-radius: 6px; transition: width .4s ease; }
+    .progress-meta { font-size: 11px; color: #888; margin-top: 6px; }
+
+    /* CTA */
+    .cta-btn {
+      display: block; width: 100%; padding: 12px;
+      background: #e65c00; color: #fff;
+      border: none; border-radius: 6px;
+      font-size: 15px; font-weight: 600; cursor: pointer;
+      text-align: center; text-decoration: none;
+      transition: background .15s;
+    }
+    .cta-btn:hover { background: #c44e00; }
+    .cta-btn:disabled { background: #ccc; cursor: not-allowed; }
+    .skip-link { display: block; text-align: center; margin-top: 12px; font-size: 12px; color: #aaa; cursor: pointer; }
+    .skip-link:hover { color: #666; }
+
+    .loading-msg { text-align: center; color: #aaa; font-size: 13px; padding: 20px 0; }
+  </style>
+</head>
+<body>
+<div x-data="onboardingPage()" x-init="load()" class="card">
+
+  <div class="logo">burnmap</div>
+  <div class="tagline">Local-first AI coding agent token dashboard</div>
+
+  <template x-if="loading">
+    <div class="loading-msg">Detecting adapters…</div>
+  </template>
+
+  <template x-if="!loading">
+    <div>
+      <h2>Adapters found</h2>
+      <ul class="adapter-list">
+        <template x-for="a in adapters" :key="a.agent">
+          <li class="adapter-item">
+            <span class="adapter-dot" :class="a.found ? 'dot-found' : 'dot-missing'"></span>
+            <span class="adapter-name" x-text="a.agent.replace('_', ' ')"></span>
+            <span x-show="a.found" class="badge-found">found</span>
+            <span x-show="!a.found" class="badge-missing">not found</span>
+            <span x-show="a.path" class="adapter-path" x-text="a.path"></span>
+          </li>
+        </template>
+      </ul>
+
+      <div class="progress-section">
+        <div class="progress-header">
+          <span>Backfill progress</span>
+          <span x-text="progress.percent_complete + '%'"></span>
+        </div>
+        <div class="progress-track">
+          <div class="progress-fill" :style="'width:' + progress.percent_complete + '%'"></div>
+        </div>
+        <div class="progress-meta">
+          <span x-text="progress.sessions_ingested + ' sessions'"></span>
+          &nbsp;·&nbsp;
+          <span x-text="progress.spans_ingested + ' spans'"></span>
+          <template x-if="progress.log_files_found > 0">
+            <span x-text="' · ' + progress.log_files_found + ' log files found'"></span>
+          </template>
+        </div>
+      </div>
+
+      <button class="cta-btn"
+              @click="openDashboard()"
+              :disabled="adapters.filter(a => a.found).length === 0">
+        Open dashboard
+      </button>
+      <span class="skip-link" @click="openDashboard()">Skip setup</span>
+    </div>
+  </template>
+
+</div>
+
+<script>
+function onboardingPage() {
+  return {
+    loading: true,
+    adapters: [],
+    progress: { percent_complete: 0, sessions_ingested: 0, spans_ingested: 0, log_files_found: 0 },
+
+    async load() {
+      this.loading = true;
+      try {
+        const [adapterRes, progressRes] = await Promise.all([
+          fetch('/api/onboarding/adapters'),
+          fetch('/api/onboarding/backfill'),
+        ]);
+        const aData = await adapterRes.json();
+        const pData = await progressRes.json();
+        this.adapters = aData.adapters || [];
+        this.progress = pData;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    openDashboard() {
+      window.location.href = '/';
+    },
+  };
+}
+</script>
+</body>
+</html>

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,126 @@
+"""Tests for onboarding API — adapter discovery and backfill progress."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from burnmap.api.onboarding import discover_adapters, query_backfill_progress
+
+
+@pytest.fixture()
+def conn(tmp_path):
+    db = sqlite3.connect(str(tmp_path / "test.db"))
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+        CREATE TABLE spans (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL DEFAULT 'sess',
+            agent TEXT NOT NULL DEFAULT 'claude_code',
+            kind TEXT NOT NULL DEFAULT 'turn',
+            name TEXT NOT NULL DEFAULT 'foo',
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0.0,
+            started_at INTEGER DEFAULT 0,
+            is_outlier INTEGER DEFAULT 0
+        );
+    """)
+    return db
+
+
+def _insert(conn, session_id="sess1"):
+    sid = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO spans (id, session_id, name) VALUES (?,?,?)",
+        (sid, session_id, "foo"),
+    )
+    conn.commit()
+    return sid
+
+
+# ── discover_adapters ─────────────────────────────────────────────────────────
+
+def test_discover_adapters_returns_all_agents():
+    adapters = discover_adapters()
+    agent_names = {a["agent"] for a in adapters}
+    assert "claude_code" in agent_names
+    assert "codex" in agent_names
+    assert "cline" in agent_names
+    assert "aider" in agent_names
+
+
+def test_discover_adapters_structure():
+    adapters = discover_adapters()
+    for a in adapters:
+        assert "agent" in a
+        assert "found" in a
+        assert isinstance(a["found"], bool)
+        assert "checked_paths" in a
+        assert isinstance(a["checked_paths"], list)
+
+
+def test_discover_adapters_found_when_path_exists(tmp_path, monkeypatch):
+    # Patch _AGENT_PATHS to point to a known existing dir
+    import burnmap.api.onboarding as mod
+    original = mod._AGENT_PATHS.copy()
+    mod._AGENT_PATHS = {"test_agent": [str(tmp_path)]}
+    try:
+        adapters = discover_adapters()
+        assert len(adapters) == 1
+        assert adapters[0]["found"] is True
+        assert adapters[0]["path"] == str(tmp_path)
+    finally:
+        mod._AGENT_PATHS = original
+
+
+def test_discover_adapters_not_found_missing_path(tmp_path, monkeypatch):
+    import burnmap.api.onboarding as mod
+    original = mod._AGENT_PATHS.copy()
+    mod._AGENT_PATHS = {"test_agent": [str(tmp_path / "nonexistent")]}
+    try:
+        adapters = discover_adapters()
+        assert adapters[0]["found"] is False
+        assert adapters[0]["path"] is None
+    finally:
+        mod._AGENT_PATHS = original
+
+
+# ── query_backfill_progress ───────────────────────────────────────────────────
+
+def test_backfill_empty_db(conn):
+    result = query_backfill_progress(conn)
+    assert result["sessions_ingested"] == 0
+    assert result["spans_ingested"] == 0
+    assert "percent_complete" in result
+    assert isinstance(result["complete"], bool)
+
+
+def test_backfill_counts_sessions(conn):
+    _insert(conn, "sess-a")
+    _insert(conn, "sess-a")  # same session
+    _insert(conn, "sess-b")
+    result = query_backfill_progress(conn)
+    assert result["sessions_ingested"] == 2
+    assert result["spans_ingested"] == 3
+
+
+def test_backfill_percent_complete_range(conn):
+    _insert(conn, "sess-x")
+    result = query_backfill_progress(conn)
+    assert 0 <= result["percent_complete"] <= 100
+
+
+def test_backfill_complete_no_log_files(conn, monkeypatch):
+    import burnmap.api.onboarding as mod
+    original = mod._AGENT_PATHS.copy()
+    # Point to nonexistent paths so log_files_found=0
+    mod._AGENT_PATHS = {"agent": ["/nonexistent/path/xyz"]}
+    try:
+        result = query_backfill_progress(conn)
+        assert result["complete"] is True  # pct=100 when no files found
+    finally:
+        mod._AGENT_PATHS = original


### PR DESCRIPTION
## Summary

Implements #24 — first-run onboarding page.

- `burnmap/api/onboarding.py`: `/api/onboarding/adapters` (per-agent found/not-found with checked paths), `/api/onboarding/backfill` (sessions ingested, spans, log files found, percent complete)
- `burnmap/templates/onboarding.html`: standalone Alpine.js page (no base template dependency) with adapter checklist, backfill progress bar, "Open dashboard" CTA (disabled until at least one adapter found), skip link
- 8 unit tests covering discovery, path detection, backfill counts, and edge cases

Closes #24

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>