### PR TITLE
feat: export page — format picker, date range, content warning

### DIFF
--- a/burnmap/api/export.py
+++ b/burnmap/api/export.py
@@ -1,0 +1,138 @@
+"""/api/export — data export endpoint (CSV/OTLP/JSON)."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sqlite3
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends, Query
+    from fastapi.responses import Response
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/export")
+    def export_data(
+        format: str = Query("CSV", pattern="^(CSV|OTLP|JSON)$"),
+        from_: str = Query("", alias="from"),
+        to: str = Query(""),
+        include_content: str = Query("0"),
+        db: sqlite3.Connection = Depends(_db),
+    ) -> Response:
+        """Export span/session data filtered by date range."""
+        rows = _query_spans(db, date_from=from_, date_to=to)
+        want_content = include_content == "1"
+        if not want_content:
+            for r in rows:
+                r.pop("content", None)
+
+        if format == "CSV":
+            return _as_csv(rows)
+        if format == "OTLP":
+            return _as_otlp(rows)
+        return _as_json(rows)
+
+else:
+    router = None  # type: ignore[assignment]
+
+
+# ── Pure helpers ──────────────────────────────────────────────────────────────
+
+def _query_spans(
+    conn: sqlite3.Connection,
+    *,
+    date_from: str = "",
+    date_to: str = "",
+) -> list[dict[str, Any]]:
+    """Query spans, optionally filtering by date range (ISO date strings YYYY-MM-DD).
+
+    started_at is stored as epoch milliseconds; convert date strings to epoch ms for comparison.
+    """
+    import datetime as _dt
+    sql = (
+        "SELECT id, session_id, agent, kind, name, "
+        "input_tokens, output_tokens, cost_usd, started_at, is_outlier "
+        "FROM spans WHERE 1=1"
+    )
+    params: list[Any] = []
+    if date_from:
+        try:
+            epoch_ms = int(_dt.datetime.fromisoformat(date_from).timestamp() * 1000)
+            sql += " AND started_at >= ?"
+            params.append(epoch_ms)
+        except ValueError:
+            pass
+    if date_to:
+        try:
+            end_dt = _dt.datetime.fromisoformat(date_to).replace(hour=23, minute=59, second=59)
+            epoch_ms = int(end_dt.timestamp() * 1000)
+            sql += " AND started_at <= ?"
+            params.append(epoch_ms)
+        except ValueError:
+            pass
+    sql += " ORDER BY started_at ASC"
+    cur = conn.execute(sql, params)
+    return [dict(row) for row in cur.fetchall()]
+
+
+def _as_csv(rows: list[dict[str, Any]]) -> "Response":
+    if not rows:
+        fieldnames = ["id", "session_id", "agent", "kind", "name",
+                      "input_tokens", "output_tokens", "cost_usd", "started_at", "ended_at"]
+    else:
+        fieldnames = list(rows[0].keys())
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+    return Response(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=burnmap-export.csv"},
+    )
+
+
+def _as_json(rows: list[dict[str, Any]]) -> "Response":
+    return Response(
+        content=json.dumps(rows, indent=2),
+        media_type="application/json",
+        headers={"Content-Disposition": "attachment; filename=burnmap-export.json"},
+    )
+
+
+def _as_otlp(rows: list[dict[str, Any]]) -> "Response":
+    """Minimal OTLP-like JSON-lines export (one span per line)."""
+    lines = [json.dumps({
+        "traceId": r.get("session_id", ""),
+        "spanId": r.get("id", ""),
+        "name": r.get("name", ""),
+        "kind": r.get("kind", ""),
+        "startTimeUnixNano": (r.get("started_at") or 0) * 1_000_000,
+        "attributes": {
+            "agent": r.get("agent", ""),
+            "input_tokens": r.get("input_tokens", 0),
+            "output_tokens": r.get("output_tokens", 0),
+            "cost_usd": r.get("cost_usd", 0.0),
+        },
+    }) for r in rows]
+    return Response(
+        content="\n".join(lines),
+        media_type="application/x-ndjson",
+        headers={"Content-Disposition": "attachment; filename=burnmap-export.jsonl"},
+    )

--- a/burnmap/templates/export.html
+++ b/burnmap/templates/export.html
@@ -1,0 +1,176 @@
+{# export.html — export page: format picker, date range, content warning, download #}
+{% extends "base.html" %}
+
+{% block title %}Export — burnmap{% endblock %}
+
+{% block content %}
+<div x-data="exportPage()" x-init="init()">
+
+  <div class="page-header">
+    <h1 class="page-title">Export</h1>
+  </div>
+
+  <!-- Content-mode warning banner -->
+  <template x-if="contentModeEnabled">
+    <div class="content-warning-banner">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="16" height="16"><path d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg>
+      <span>Content mode is enabled. Exports may include prompt text and model responses.</span>
+    </div>
+  </template>
+
+  <div class="export-form">
+
+    <!-- Format picker -->
+    <div class="form-section">
+      <label class="form-label">Format</label>
+      <div class="format-toggle">
+        <template x-for="fmt in formats" :key="fmt">
+          <button class="format-btn"
+                  :class="format === fmt ? 'format-btn--active' : ''"
+                  @click="format = fmt"
+                  x-text="fmt"></button>
+        </template>
+      </div>
+    </div>
+
+    <!-- Date range -->
+    <div class="form-section">
+      <label class="form-label">Date range</label>
+      <div class="date-range">
+        <input type="date" class="date-input" x-model="dateFrom" />
+        <span class="date-sep">to</span>
+        <input type="date" class="date-input" x-model="dateTo" />
+      </div>
+    </div>
+
+    <!-- Include content checkbox (only shown when content mode enabled) -->
+    <template x-if="contentModeEnabled">
+      <div class="form-section">
+        <label class="checkbox-label">
+          <input type="checkbox" x-model="includeContent" class="checkbox-input" />
+          <span>Include prompt content in export</span>
+        </label>
+        <p class="form-hint">When checked, exported data will include raw prompt text and model responses.</p>
+      </div>
+    </template>
+
+    <!-- Download button -->
+    <div class="form-section">
+      <button class="btn-download"
+              :disabled="downloading"
+              @click="download()">
+        <template x-if="!downloading">
+          <span>Download <span x-text="format"></span></span>
+        </template>
+        <template x-if="downloading">
+          <span>Preparing…</span>
+        </template>
+      </button>
+      <template x-if="error">
+        <p class="error-msg" x-text="error"></p>
+      </template>
+    </div>
+
+  </div>
+
+</div>
+
+<script>
+function exportPage() {
+  return {
+    formats: ['CSV', 'OTLP', 'JSON'],
+    format: 'CSV',
+    dateFrom: '',
+    dateTo: '',
+    includeContent: false,
+    contentModeEnabled: false,
+    downloading: false,
+    error: null,
+
+    async init() {
+      // Detect content mode from settings API
+      try {
+        const r = await fetch('/api/settings');
+        if (r.ok) {
+          const s = await r.json();
+          this.contentModeEnabled = !!(s.content_mode);
+        }
+      } catch (_) { /* settings API optional */ }
+
+      // Default date range: last 30 days
+      const now = new Date();
+      this.dateTo = now.toISOString().slice(0, 10);
+      now.setDate(now.getDate() - 30);
+      this.dateFrom = now.toISOString().slice(0, 10);
+    },
+
+    async download() {
+      this.downloading = true;
+      this.error = null;
+      try {
+        const params = new URLSearchParams({
+          format: this.format,
+          from: this.dateFrom,
+          to: this.dateTo,
+          include_content: this.includeContent ? '1' : '0',
+        });
+        const r = await fetch(`/api/export?${params}`);
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}));
+          throw new Error(body.detail || `Export failed (${r.status})`);
+        }
+        const blob = await r.blob();
+        const ext = this.format === 'CSV' ? 'csv' : this.format === 'JSON' ? 'json' : 'jsonl';
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `burnmap-export.${ext}`;
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (e) {
+        this.error = e.message;
+      } finally {
+        this.downloading = false;
+      }
+    },
+  };
+}
+</script>
+
+<style>
+.page-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px; }
+.page-title { font-size: 20px; font-weight: 600; }
+
+.content-warning-banner {
+  display: flex; align-items: center; gap: 8px;
+  background: #fff3cd; border: 1px solid #ffc107; border-radius: 6px;
+  padding: 10px 14px; margin-bottom: 20px; font-size: 13px; color: #856404;
+}
+
+.export-form { max-width: 480px; display: flex; flex-direction: column; gap: 24px; }
+
+.form-section { display: flex; flex-direction: column; gap: 8px; }
+.form-label { font-size: 12px; font-weight: 700; color: var(--ink-3, #888); text-transform: uppercase; letter-spacing: .05em; }
+.form-hint { font-size: 12px; color: var(--ink-3, #888); margin: 0; }
+
+.format-toggle { display: flex; gap: 0; border: 1px solid var(--rule-soft, #ddd); border-radius: 6px; overflow: hidden; width: fit-content; }
+.format-btn { font-size: 13px; padding: 6px 18px; border: none; background: none; cursor: pointer; border-right: 1px solid var(--rule-soft, #ddd); }
+.format-btn:last-child { border-right: none; }
+.format-btn--active { background: var(--accent, #e65c00); color: #fff; font-weight: 600; }
+
+.date-range { display: flex; align-items: center; gap: 8px; }
+.date-input { font-size: 13px; padding: 6px 10px; border: 1px solid var(--rule-soft, #ddd); border-radius: 4px; }
+.date-sep { font-size: 13px; color: var(--ink-3, #888); }
+
+.checkbox-label { display: flex; align-items: center; gap: 8px; font-size: 13px; cursor: pointer; }
+.checkbox-input { width: 15px; height: 15px; cursor: pointer; }
+
+.btn-download {
+  font-size: 14px; font-weight: 600; padding: 10px 24px;
+  background: var(--accent, #e65c00); color: #fff; border: none;
+  border-radius: 6px; cursor: pointer; width: fit-content;
+}
+.btn-download:disabled { opacity: 0.6; cursor: not-allowed; }
+.error-msg { color: #c0392b; font-size: 13px; margin: 0; }
+</style>
+{% endblock %}

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,151 @@
+"""Tests for the export page template and export API helpers — issue #23."""
+from __future__ import annotations
+
+import sqlite3
+import pytest
+from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+
+from burnmap.api.export import _query_spans, _as_csv, _as_json, _as_otlp
+from burnmap.db.schema import init_db
+
+TEMPLATES_DIR = Path(__file__).parent.parent / "burnmap" / "templates"
+
+
+@pytest.fixture(scope="module")
+def env():
+    return Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape=False)
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    init_db(c)
+    yield c
+    c.close()
+
+
+# ── Template tests ────────────────────────────────────────────────────────────
+
+def test_export_template_renders(env):
+    tmpl = env.get_template("export.html")
+    # base.html may not be present in tests; just check it parses correctly
+    # by checking the template source for key elements
+    src = tmpl.source if hasattr(tmpl, "source") else ""
+    # Load raw template text instead
+    raw = (TEMPLATES_DIR / "export.html").read_text()
+    assert "format-toggle" in raw
+    assert "date-input" in raw
+    assert "content-warning-banner" in raw
+    assert "checkbox-input" in raw
+    assert "btn-download" in raw
+
+
+def test_export_template_has_all_formats(env):
+    raw = (TEMPLATES_DIR / "export.html").read_text()
+    assert "CSV" in raw
+    assert "OTLP" in raw
+    assert "JSON" in raw
+
+
+def test_export_template_download_triggers_api(env):
+    raw = (TEMPLATES_DIR / "export.html").read_text()
+    assert "/api/export" in raw
+
+
+def test_export_template_content_warning(env):
+    raw = (TEMPLATES_DIR / "export.html").read_text()
+    assert "content-warning-banner" in raw
+    assert "contentModeEnabled" in raw
+
+
+def test_export_template_include_content_checkbox(env):
+    raw = (TEMPLATES_DIR / "export.html").read_text()
+    assert "includeContent" in raw
+    assert "include_content" in raw
+
+
+# ── API helper tests ──────────────────────────────────────────────────────────
+
+import datetime as _dt
+
+
+def _to_epoch_ms(iso_date: str) -> int:
+    return int(_dt.datetime.fromisoformat(iso_date).timestamp() * 1000)
+
+
+def _insert_span(conn, span_id, started_at_iso):
+    conn.execute(
+        "INSERT INTO spans (id, session_id, agent, kind, name, input_tokens, output_tokens, cost_usd, started_at) "
+        "VALUES (?, 'sess1', 'claude', 'llm', 'test', 100, 50, 0.001, ?)",
+        [span_id, _to_epoch_ms(started_at_iso)],
+    )
+    conn.commit()
+
+
+def test_query_spans_returns_all(conn):
+    _insert_span(conn, "s1", "2024-01-15T10:00:00")
+    _insert_span(conn, "s2", "2024-02-15T10:00:00")
+    rows = _query_spans(conn)
+    assert len(rows) >= 2
+
+
+def test_query_spans_date_from_filter(conn):
+    _insert_span(conn, "sf1", "2024-03-01T00:00:00")
+    _insert_span(conn, "sf2", "2024-03-20T00:00:00")
+    rows = _query_spans(conn, date_from="2024-03-15")
+    ids = [r["id"] for r in rows]
+    assert "sf2" in ids
+    assert "sf1" not in ids
+
+
+def test_query_spans_date_to_filter(conn):
+    _insert_span(conn, "st1", "2024-04-01T00:00:00")
+    _insert_span(conn, "st2", "2024-04-20T00:00:00")
+    rows = _query_spans(conn, date_to="2024-04-10")
+    ids = [r["id"] for r in rows]
+    assert "st1" in ids
+    assert "st2" not in ids
+
+
+def test_as_csv_empty():
+    resp = _as_csv([])
+    assert resp.media_type == "text/csv"
+    assert "id" in resp.body.decode()
+
+
+def test_as_csv_with_rows():
+    rows = [{"id": "x1", "session_id": "s", "agent": "a", "kind": "k",
+             "name": "n", "input_tokens": 10, "output_tokens": 5,
+             "cost_usd": 0.001, "started_at": 1704067200000, "is_outlier": 0}]
+    resp = _as_csv(rows)
+    body = resp.body.decode()
+    assert "x1" in body
+    assert "id,session_id" in body
+
+
+def test_as_json_with_rows():
+    import json
+    rows = [{"id": "j1", "name": "test"}]
+    resp = _as_json(rows)
+    assert resp.media_type == "application/json"
+    data = json.loads(resp.body)
+    assert data[0]["id"] == "j1"
+
+
+def test_as_otlp_with_rows():
+    import json
+    rows = [{"id": "o1", "session_id": "s", "name": "n", "kind": "llm",
+             "started_at": 1704067200000, "agent": "claude",
+             "input_tokens": 10, "output_tokens": 5, "cost_usd": 0.001}]
+    resp = _as_otlp(rows)
+    assert "ndjson" in resp.media_type
+    obj = json.loads(resp.body.decode().strip())
+    assert obj["spanId"] == "o1"
+    assert obj["attributes"]["input_tokens"] == 10
+
+
+def test_as_otlp_empty():
+    resp = _as_otlp([])
+    assert resp.body == b""


### PR DESCRIPTION
## Summary

Adds export page with:
- Format toggle (CSV/OTLP/JSON)
- Date range selector
- Content-mode warning banner
- Include-content opt-in checkbox
- Download API call to /api/export

13 tests passing, all acceptance criteria met.

Closes #23