### PR TITLE
feat: quota page — 5h block + weekly panels

### DIFF
--- a/burnmap/api/__init__.py
+++ b/burnmap/api/__init__.py
@@ -1,4 +1,5 @@
 from .tasks import router as tasks_router
 from .providers import router as providers_router
+from .quota import router as quota_router
 
-__all__ = ["tasks_router", "providers_router"]
+__all__ = ["tasks_router", "providers_router", "quota_router"]

--- a/burnmap/api/quota.py
+++ b/burnmap/api/quota.py
@@ -1,0 +1,156 @@
+"""/api/quota — rolling 5-hour block and weekly window data for the Quota page."""
+from __future__ import annotations
+
+import sqlite3
+import time
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends
+    from fastapi.responses import JSONResponse
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/quota")
+    def quota_data(db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
+        return JSONResponse(query_quota(db))
+
+else:
+    router = None  # type: ignore[assignment]
+
+
+# Plan limits in USD
+_PLAN_LIMITS: dict[str, dict[str, float]] = {
+    "Pro":    {"block": 18.0,  "week": 180.0},
+    "Max5":   {"block": 90.0,  "week": 900.0},
+    "Max20":  {"block": 380.0, "week": 3800.0},
+    "Custom": {"block": 0.0,   "week": 0.0},
+}
+_BLOCK_SECS = 5 * 3600      # 5 hours
+_WEEK_SECS  = 7 * 24 * 3600  # 7 days
+
+
+def query_quota(conn: sqlite3.Connection, plan: str = "Max20") -> dict[str, Any]:
+    """Return current block stats, weekly stats, and recent block grid."""
+    now_ms = int(time.time() * 1000)
+    block_start_ms = now_ms - _BLOCK_SECS * 1000
+    week_start_ms  = now_ms - _WEEK_SECS  * 1000
+
+    limits = _PLAN_LIMITS.get(plan, _PLAN_LIMITS["Max20"])
+    block_limit = limits["block"]
+    week_limit  = limits["week"]
+
+    # Current 5-hour block cost
+    row = conn.execute(
+        "SELECT COALESCE(SUM(cost_usd),0) FROM turns WHERE ts >= ?",
+        (block_start_ms,),
+    ).fetchone()
+    block_cost: float = row[0] if row else 0.0
+
+    # Weekly window cost
+    row = conn.execute(
+        "SELECT COALESCE(SUM(cost_usd),0) FROM turns WHERE ts >= ?",
+        (week_start_ms,),
+    ).fetchone()
+    week_cost: float = row[0] if row else 0.0
+
+    # P90 of past 5-hour block totals (last 30 days for enough history)
+    thirty_days_ms = now_ms - 30 * 24 * 3600 * 1000
+    rows = conn.execute(
+        """
+        SELECT
+            (ts / ?) * ? AS block_bucket,
+            SUM(cost_usd) AS total
+        FROM turns
+        WHERE ts >= ?
+        GROUP BY block_bucket
+        ORDER BY block_bucket
+        """,
+        (_BLOCK_SECS * 1000, _BLOCK_SECS * 1000, thirty_days_ms),
+    ).fetchall()
+    block_totals = sorted([r[1] for r in rows])
+    p90_block = _percentile(block_totals, 90) if block_totals else block_limit
+
+    # Recent 5-hour blocks grid (last 72h = last 14 blocks)
+    grid_start_ms = now_ms - 72 * 3600 * 1000
+    grid_rows = conn.execute(
+        """
+        SELECT
+            (ts / ?) * ? AS bucket,
+            SUM(cost_usd) AS total
+        FROM turns
+        WHERE ts >= ?
+        GROUP BY bucket
+        ORDER BY bucket
+        """,
+        (_BLOCK_SECS * 1000, _BLOCK_SECS * 1000, grid_start_ms),
+    ).fetchall()
+
+    blocks = []
+    for r in grid_rows:
+        bucket_ms: int = int(r[0])
+        cost: float = r[1]
+        t = time.gmtime(bucket_ms // 1000)
+        blocks.append({
+            "day":   time.strftime("%a %d", t),
+            "label": time.strftime("%H:%M", t),
+            "cost":  round(cost, 2),
+            "pct":   min(cost / block_limit, 1.0) if block_limit else 0.0,
+            "stuck": False,  # placeholder — stuck detection is in loop_detect.py
+        })
+
+    block_pct = min(block_cost / block_limit, 1.0) if block_limit else 0.0
+    week_pct  = min(week_cost  / week_limit,  1.0) if week_limit  else 0.0
+
+    def _eta_label(remaining: float, elapsed_sec: float, total_sec: float) -> str:
+        if remaining <= 0:
+            return "at limit"
+        rate = block_cost / elapsed_sec if elapsed_sec > 0 else 0
+        if rate <= 0:
+            return "—"
+        eta_sec = remaining / rate
+        if eta_sec < 60:
+            return "< 1 min"
+        if eta_sec < 3600:
+            return f"{int(eta_sec/60)}m"
+        return f"{eta_sec/3600:.1f}h"
+
+    block_elapsed = (now_ms - block_start_ms) / 1000
+    week_elapsed  = (now_ms - week_start_ms)  / 1000
+
+    return {
+        "plan":       plan,
+        "block_cost": round(block_cost, 2),
+        "block_limit": block_limit,
+        "block_pct":  round(block_pct, 4),
+        "block_eta":  _eta_label(block_limit - block_cost, block_elapsed, _BLOCK_SECS),
+        "week_cost":  round(week_cost, 2),
+        "week_limit": week_limit,
+        "week_pct":   round(week_pct, 4),
+        "week_eta":   _eta_label(week_limit - week_cost, week_elapsed, _WEEK_SECS),
+        "p90_block":  round(p90_block, 2),
+        "blocks":     blocks,
+        "plans":      list(_PLAN_LIMITS.keys()),
+    }
+
+
+def _percentile(data: list[float], p: int) -> float:
+    if not data:
+        return 0.0
+    k = (len(data) - 1) * p / 100
+    lo, hi = int(k), min(int(k) + 1, len(data) - 1)
+    return data[lo] + (data[hi] - data[lo]) * (k - lo)

--- a/burnmap/templates/pages/quota.html
+++ b/burnmap/templates/pages/quota.html
@@ -1,0 +1,157 @@
+{# quota.html — Quota page: 5-hour block + weekly window + recent blocks grid + plan selector #}
+{% extends "base.html" %}
+
+{% block title %}Quotas — burnmap{% endblock %}
+
+{% block content %}
+<div x-data="quotaPage()" x-init="load()">
+
+  <div class="page-header">
+    <h1 class="page-title">Quotas · Claude subscription</h1>
+    <span class="meta" x-text="plan + ' plan · P90 auto-detected'">Max20 plan · P90 auto-detected</span>
+  </div>
+
+  <p class="page-sub">Rolling 5-hour blocks and the weekly window. Marks indicate your historical P90 ceiling.</p>
+
+  <template x-if="loading">
+    <div class="loading-row">Loading…</div>
+  </template>
+
+  <template x-if="!loading">
+    <div>
+
+      <!-- Current block + weekly window -->
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:16px">
+
+        <!-- Current 5-hour block -->
+        <div class="card">
+          <div class="card__h">
+            <h3>Current 5-hour block</h3>
+            <span class="spacer"></span>
+            <span class="mono muted" style="font-size:11px" x-text="data.block_eta"></span>
+          </div>
+          <div class="card__body">
+            <div class="row" style="align-items:baseline;gap:10px">
+              <span class="num" style="font-size:34px" x-text="'$' + data.block_cost.toFixed(2)">$0.00</span>
+              <span class="muted mono" style="font-size:12px"
+                x-text="'of ~$' + data.block_limit + ' · ' + (data.block_pct*100).toFixed(0) + '%'"></span>
+              <span class="spacer"></span>
+            </div>
+            <!-- Progress bar -->
+            <div style="position:relative;height:18px;background:var(--rule-soft);border-radius:3px;margin-top:10px;overflow:hidden">
+              <div :style="'height:100%;border-radius:3px;background:' + (data.block_pct > 0.9 ? '#ef4444' : data.block_pct > 0.7 ? '#f59e0b' : 'var(--accent)') + ';width:' + (data.block_pct*100).toFixed(1) + '%'"></div>
+            </div>
+            <!-- P90 label -->
+            <div class="row" style="font-size:11px;margin-top:6px">
+              <span>0</span>
+              <span class="spacer"></span>
+              <span x-text="'P90 · $' + data.p90_block"></span>
+              <span class="spacer"></span>
+              <span x-text="'$' + data.block_limit"></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Weekly window -->
+        <div class="card">
+          <div class="card__h">
+            <h3>Weekly window</h3>
+            <span class="spacer"></span>
+            <span class="mono muted" style="font-size:11px" x-text="data.week_eta"></span>
+          </div>
+          <div class="card__body">
+            <div class="row" style="align-items:baseline;gap:10px">
+              <span class="num" style="font-size:34px" x-text="'$' + data.week_cost.toFixed(0)">$0</span>
+              <span class="muted mono" style="font-size:12px"
+                x-text="'of ~$' + data.week_limit + ' · ' + (data.week_pct*100).toFixed(0) + '%'"></span>
+            </div>
+            <!-- Progress bar -->
+            <div style="position:relative;height:18px;background:var(--rule-soft);border-radius:3px;margin-top:10px;overflow:hidden">
+              <div :style="'height:100%;border-radius:3px;background:' + (data.week_pct > 0.9 ? '#ef4444' : data.week_pct > 0.7 ? '#f59e0b' : 'var(--accent)') + ';width:' + (data.week_pct*100).toFixed(1) + '%'"></div>
+            </div>
+            <div class="row" style="font-size:11px;margin-top:6px">
+              <span>0</span>
+              <span class="spacer"></span>
+              <span x-text="'$' + data.week_limit"></span>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Recent 5-hour blocks grid (last 72h) -->
+      <div class="card" style="margin-bottom:16px">
+        <div class="card__h">
+          <h3>Recent 5-hour blocks</h3>
+          <span class="meta">last 72h</span>
+        </div>
+        <div class="card__body">
+          <template x-if="data.blocks.length === 0">
+            <p class="muted mono" style="font-size:12px">No block data in the last 72 hours.</p>
+          </template>
+          <div style="display:grid;grid-template-columns:repeat(8,1fr);gap:8px">
+            <template x-for="(b, i) in data.blocks" :key="i">
+              <div :style="'border:1px solid var(--rule-soft);border-radius:4px;padding:10px;background:' + (b.stuck ? '#fdf1f1' : 'var(--paper)')">
+                <div class="mono muted" style="font-size:10px" x-text="b.day + ' · ' + b.label"></div>
+                <div class="num" style="font-size:15px;margin-top:4px" x-text="'$' + b.cost.toFixed(2)"></div>
+                <!-- Mini bar -->
+                <div style="height:4px;background:var(--rule-soft);border-radius:2px;margin-top:6px">
+                  <div :style="'height:100%;border-radius:2px;background:' + (b.stuck ? '#ef4444' : 'var(--accent)') + ';width:' + (b.pct*100).toFixed(1) + '%'"></div>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <!-- Plan selector -->
+      <div class="card">
+        <div class="card__h"><h3>Plan</h3></div>
+        <div class="card__body">
+          <div class="row" style="gap:8px">
+            <template x-for="p in data.plans" :key="p">
+              <button
+                class="btn"
+                :style="plan === p ? 'border-color:var(--ink);background:var(--paper-2)' : ''"
+                @click="selectPlan(p)"
+                x-text="p">
+              </button>
+            </template>
+            <span class="spacer"></span>
+            <span class="mono muted" style="font-size:11px">P90 auto · last recomputed at load</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </template>
+
+</div>
+
+<script>
+function quotaPage() {
+  return {
+    loading: true,
+    plan: 'Max20',
+    data: {
+      block_cost: 0, block_limit: 380, block_pct: 0, block_eta: '—',
+      week_cost: 0,  week_limit: 3800, week_pct: 0,  week_eta: '—',
+      p90_block: 0, blocks: [], plans: ['Pro','Max5','Max20','Custom'],
+    },
+
+    async load() {
+      this.loading = true;
+      const r = await fetch('/api/quota?plan=' + encodeURIComponent(this.plan));
+      this.data = await r.json();
+      this.plan = this.data.plan;
+      this.loading = false;
+    },
+
+    selectPlan(p) {
+      this.plan = p;
+      this.load();
+    },
+  };
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
Closes #20

## Implementation
- API endpoint /api/quota returns current/weekly block stats, P90 ceiling, recent blocks grid
- Quota page template with:
  - Current 5-hour block progress bar and ETA
  - Weekly window progress bar and ETA
  - Recent 5-hour blocks grid (last 72h, 8-column layout)
  - Plan selector (Pro, Max5, Max20, Custom)

## Acceptance Criteria
- [x] Current block with progress bar and ETA
- [x] Weekly window with progress bar
- [x] Recent 5h blocks grid (last 72h)
- [x] Plan selector buttons

## Follows
Mockup in docs-t01-burnmap/mockups/project/pages/others.jsx