### PR TITLE
feat: token gate — auth when HOST != localhost

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -1,0 +1,41 @@
+"""FastAPI application factory for t01-burnmap."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pathlib import Path
+
+from burnmap.auth import TokenAuthMiddleware
+from burnmap.api import tasks_router, providers_router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="t01-burnmap", version="0.1.0")
+
+    if TokenAuthMiddleware is not None:
+        app.add_middleware(TokenAuthMiddleware)
+
+    app.include_router(tasks_router)
+    app.include_router(providers_router)
+
+    # Optional routers (only available if imported)
+    try:
+        from burnmap.api.outlier_review import router as outlier_router
+        if outlier_router is not None:
+            app.include_router(outlier_router)
+    except ImportError:
+        pass
+
+    try:
+        from burnmap.api.onboarding import router as onboarding_router
+        if onboarding_router is not None:
+            app.include_router(onboarding_router)
+    except ImportError:
+        pass
+
+    static_dir = Path(__file__).parent / "static"
+    if static_dir.exists():
+        app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    return app

--- a/burnmap/auth.py
+++ b/burnmap/auth.py
@@ -1,0 +1,61 @@
+"""Token-based auth gate for non-localhost deployments."""
+from __future__ import annotations
+
+import secrets
+import sqlite3
+from pathlib import Path
+
+_TOKEN_FILE = Path.home() / ".t01-burnmap" / "token"
+
+
+def generate_token() -> str:
+    """Generate, store, and return a new bearer token."""
+    token = secrets.token_hex(32)
+    _TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _TOKEN_FILE.write_text(token)
+    return token
+
+
+def load_token() -> str | None:
+    """Return stored token, or None if no token exists."""
+    if _TOKEN_FILE.exists():
+        return _TOKEN_FILE.read_text().strip() or None
+    return None
+
+
+def is_local_request(host: str) -> bool:
+    """Return True if the request host is localhost or 127.x or ::1."""
+    if not host:
+        return False
+    # Strip port for IPv4/hostname (host:port), but preserve IPv6 (::1)
+    if host == "::1" or host.startswith("["):
+        return True
+    h = host.split(":")[0]
+    return h in ("localhost", "127.0.0.1") or h.startswith("127.")
+
+
+try:
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class TokenAuthMiddleware(BaseHTTPMiddleware):
+        """Enforce bearer token auth for non-localhost requests."""
+
+        async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+            host = request.headers.get("host", "localhost")
+            if is_local_request(host):
+                return await call_next(request)
+
+            token = load_token()
+            if token is None:
+                return await call_next(request)  # auth disabled if no token configured
+
+            auth_header = request.headers.get("authorization", "")
+            if auth_header == f"Bearer {token}":
+                return await call_next(request)
+
+            return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
+except ImportError:
+    TokenAuthMiddleware = None  # type: ignore[assignment,misc]

--- a/burnmap/cli.py
+++ b/burnmap/cli.py
@@ -15,9 +15,15 @@ def main() -> None:
         print("Commands:")
         print("  sweep         Run 2-sigma outlier sweep on all spans")
         print("  sync-pricing  Refresh pricing.yaml from LiteLLM upstream")
+        print("  token         Manage auth tokens (--create)")
+        print("  serve         Start the FastAPI server (--host, --port, --reload)")
         return
 
-    if args[0] == "sweep":
+    if args[0] == "token":
+        _cmd_token(args[1:])
+    elif args[0] == "serve":
+        _cmd_serve(args[1:])
+    elif args[0] == "sweep":
         conn = get_db()
         init_db(conn)
         result = sweep(conn)
@@ -31,6 +37,37 @@ def main() -> None:
     else:
         print(f"Unknown command: {args[0]}", file=sys.stderr)
         sys.exit(1)
+
+
+def _cmd_token(args: list[str]) -> None:
+    from burnmap.auth import generate_token, load_token
+    if "--create" in args:
+        token = generate_token()
+        print(f"[burnmap token] generated: {token}")
+    else:
+        token = load_token()
+        if token:
+            print(f"[burnmap token] token exists (use --create to rotate)")
+        else:
+            print("[burnmap token] no token set. Use --create to generate one.")
+
+
+def _cmd_serve(args: list[str]) -> None:
+    import uvicorn  # type: ignore[import]
+    host = "127.0.0.1"
+    port = 7820
+    reload = False
+    i = 0
+    while i < len(args):
+        if args[i] == "--host" and i + 1 < len(args):
+            host = args[i + 1]; i += 2
+        elif args[i] == "--port" and i + 1 < len(args):
+            port = int(args[i + 1]); i += 2
+        elif args[i] == "--reload":
+            reload = True; i += 1
+        else:
+            i += 1
+    uvicorn.run("burnmap.app:create_app", host=host, port=port, reload=reload, factory=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,110 @@
+"""Tests for token gate auth (burnmap/auth.py)."""
+from __future__ import annotations
+
+import pytest
+from burnmap.auth import generate_token, is_local_request, load_token
+
+
+class TestIsLocalRequest:
+    def test_localhost(self):
+        assert is_local_request("localhost") is True
+
+    def test_localhost_with_port(self):
+        assert is_local_request("localhost:7820") is True
+
+    def test_127_0_0_1(self):
+        assert is_local_request("127.0.0.1") is True
+
+    def test_127_subnet(self):
+        assert is_local_request("127.0.0.2") is True
+
+    def test_ipv6_loopback(self):
+        assert is_local_request("::1") is True
+
+    def test_remote_ip(self):
+        assert is_local_request("192.168.1.1") is False
+
+    def test_remote_hostname(self):
+        assert is_local_request("myserver.example.com") is False
+
+    def test_empty_host(self):
+        assert is_local_request("") is False
+
+
+class TestTokenGeneration:
+    def test_generate_creates_token(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "token")
+        token = generate_token()
+        assert len(token) == 64  # 32 bytes hex = 64 chars
+        assert (tmp_path / "token").read_text() == token
+
+    def test_load_returns_generated(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "token")
+        token = generate_token()
+        assert load_token() == token
+
+    def test_load_returns_none_if_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "nonexistent")
+        assert load_token() is None
+
+
+try:
+    from fastapi.testclient import TestClient
+    from fastapi import FastAPI
+    from fastapi.responses import JSONResponse
+    from burnmap.auth import TokenAuthMiddleware
+
+    def _make_app(token_file=None, monkeypatch=None):
+        import burnmap.auth as auth_mod
+        app = FastAPI()
+        if TokenAuthMiddleware is not None:
+            app.add_middleware(TokenAuthMiddleware)
+
+        @app.get("/ping")
+        def ping():
+            return JSONResponse({"ok": True})
+
+        return app
+
+    class TestTokenAuthMiddleware:
+        def test_localhost_bypasses_auth(self, tmp_path, monkeypatch):
+            monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "token")
+            generate_token()
+            app = _make_app()
+            client = TestClient(app, headers={"host": "localhost"})
+            resp = client.get("/ping")
+            assert resp.status_code == 200
+
+        def test_remote_without_token_header_returns_401(self, tmp_path, monkeypatch):
+            monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "token")
+            generate_token()
+            app = _make_app()
+            client = TestClient(app, headers={"host": "remoteserver.example.com"}, raise_server_exceptions=False)
+            resp = client.get("/ping")
+            assert resp.status_code == 401
+
+        def test_remote_with_valid_token_passes(self, tmp_path, monkeypatch):
+            monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "token")
+            token = generate_token()
+            app = _make_app()
+            client = TestClient(app, headers={"host": "remoteserver.example.com", "authorization": f"Bearer {token}"}, raise_server_exceptions=False)
+            resp = client.get("/ping")
+            assert resp.status_code == 200
+
+        def test_remote_with_wrong_token_returns_401(self, tmp_path, monkeypatch):
+            monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "token")
+            generate_token()
+            app = _make_app()
+            client = TestClient(app, headers={"host": "remoteserver.example.com", "authorization": "Bearer wrongtoken"}, raise_server_exceptions=False)
+            resp = client.get("/ping")
+            assert resp.status_code == 401
+
+        def test_no_token_configured_passes_all(self, tmp_path, monkeypatch):
+            monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "nonexistent")
+            app = _make_app()
+            client = TestClient(app, headers={"host": "remoteserver.example.com"}, raise_server_exceptions=False)
+            resp = client.get("/ping")
+            assert resp.status_code == 200
+
+except ImportError:
+    pass  # FastAPI not installed in test env


### PR DESCRIPTION
Closes #14

## Summary
Implement token-based auth gate for non-localhost deployments.

## Changes
- Add TokenAuthMiddleware (checks Bearer token for non-localhost)
- Add burnmap/auth.py: token generation/loading, localhost detection
- Add burnmap/app.py: FastAPI app factory with middleware wired in
- Add token/serve CLI commands
- Add 16 tests for both auth paths (localhost and remote)

## Acceptance Criteria
- [x] Middleware checks Authorization header on non-localhost
- [x] `burnmap token --create` generates and stores token
- [x] 401 for missing/invalid token
- [x] Localhost bypasses auth
- [x] Tests for both paths