### PR TITLE
feat: prompts page — list, detail, histogram, outlier flags

### DIFF
--- a/burnmap/api/__init__.py
+++ b/burnmap/api/__init__.py
@@ -5,5 +5,6 @@ from .trace import router as trace_router
 from .tools import router as tools_router
 from .sessions import router as sessions_router
 from .settings import router as settings_router
+from .prompts import router as prompts_router
 
-__all__ = ["tasks_router", "providers_router", "quota_router", "trace_router", "tools_router", "sessions_router", "settings_router"]
+__all__ = ["tasks_router", "providers_router", "quota_router", "trace_router", "tools_router", "sessions_router", "settings_router", "prompts_router"]

--- a/burnmap/api/prompts.py
+++ b/burnmap/api/prompts.py
@@ -1,0 +1,169 @@
+"""/api/prompts — prompt list with search/sort and detail with histogram + outlier flags."""
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends, Query
+    from fastapi.responses import JSONResponse
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/prompts")
+    def list_prompts(
+        search: str | None = Query(None, description="Filter by prompt text substring"),
+        sort: str | None = Query("cost", description="Sort by: cost|runs|tokens|recent"),
+        limit: int = Query(100, ge=1, le=1000),
+        db: sqlite3.Connection = Depends(_db),
+    ) -> JSONResponse:
+        rows = query_prompts(db, search=search, sort=sort, limit=limit)
+        return JSONResponse({"prompts": rows, "count": len(rows)})
+
+    @router.get("/api/prompts/{fingerprint}")
+    def get_prompt_detail(
+        fingerprint: str,
+        db: sqlite3.Connection = Depends(_db),
+    ) -> JSONResponse:
+        detail = query_prompt_detail(db, fingerprint=fingerprint)
+        if detail is None:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=404, detail="Prompt not found")
+        return JSONResponse(detail)
+
+else:
+    router = None  # type: ignore[assignment]
+
+
+_VALID_SORTS = {"cost", "runs", "tokens", "recent"}
+
+
+def query_prompts(
+    conn: sqlite3.Connection,
+    *,
+    search: str | None = None,
+    sort: str | None = "cost",
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return prompt list rows with agent badges and outlier flag."""
+    sort = sort if sort in _VALID_SORTS else "cost"
+    order_map = {
+        "cost": "p.total_cost DESC",
+        "runs": "p.run_count DESC",
+        "tokens": "p.total_tokens DESC",
+        "recent": "p.last_seen DESC",
+    }
+    order = order_map[sort]
+
+    where_clauses: list[str] = []
+    params: list[Any] = []
+
+    if search:
+        where_clauses.append("(pc.content LIKE ? OR p.fingerprint LIKE ?)")
+        params.extend([f"%{search}%", f"%{search}%"])
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    cur = conn.execute(
+        f"""
+        SELECT
+            p.fingerprint                                   AS fingerprint,
+            COALESCE(SUBSTR(pc.content, 1, 120), '(no text)')  AS snippet,
+            p.run_count                                     AS run_count,
+            p.total_tokens                                  AS total_tokens,
+            p.total_cost                                    AS total_cost,
+            p.first_seen                                    AS first_seen,
+            p.last_seen                                     AS last_seen,
+            COALESCE(s.agent, '—')                          AS agent,
+            COALESCE(MAX(sp.is_outlier), 0)                 AS is_outlier
+        FROM prompts p
+        LEFT JOIN prompt_content pc ON pc.fingerprint = p.fingerprint
+        LEFT JOIN prompt_runs pr ON pr.fingerprint = p.fingerprint
+        LEFT JOIN sessions s ON s.id = pr.session_id
+        LEFT JOIN spans sp ON sp.session_id = pr.session_id
+        {where_sql}
+        GROUP BY p.fingerprint
+        ORDER BY {order}
+        LIMIT ?
+        """,
+        (*params, limit),
+    )
+    return [dict(r) for r in cur.fetchall()]
+
+
+def query_prompt_detail(
+    conn: sqlite3.Connection,
+    *,
+    fingerprint: str,
+) -> dict[str, Any] | None:
+    """Return prompt detail: text, stats, run histogram, outlier flags, run list."""
+    row = conn.execute(
+        """
+        SELECT
+            p.fingerprint, p.run_count, p.total_tokens, p.total_cost,
+            p.first_seen, p.last_seen,
+            COALESCE(pc.content, '(no text)') AS content
+        FROM prompts p
+        LEFT JOIN prompt_content pc ON pc.fingerprint = p.fingerprint
+        WHERE p.fingerprint = ?
+        """,
+        (fingerprint,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    detail = dict(row)
+
+    # Per-run cost histogram buckets (10 buckets)
+    runs = conn.execute(
+        """
+        SELECT pr.ts, pr.cost_usd, pr.input_tokens, pr.session_id,
+               COALESCE(sp.is_outlier, 0) AS is_outlier_run
+        FROM prompt_runs pr
+        LEFT JOIN spans sp ON sp.session_id = pr.session_id
+        WHERE pr.fingerprint = ?
+        ORDER BY pr.ts DESC
+        LIMIT 500
+        """,
+        (fingerprint,),
+    ).fetchall()
+
+    run_list = [dict(r) for r in runs]
+
+    # Build histogram: bucket by cost
+    costs = [r["cost_usd"] for r in run_list if r["cost_usd"] is not None]
+    histogram: list[dict[str, Any]] = []
+    if costs:
+        mn, mx = min(costs), max(costs)
+        bucket_size = (mx - mn) / 10 if mx > mn else 1.0
+        buckets: dict[int, int] = {}
+        for c in costs:
+            b = min(int((c - mn) / bucket_size), 9)
+            buckets[b] = buckets.get(b, 0) + 1
+        histogram = [
+            {"bucket_start": round(mn + i * bucket_size, 6), "count": buckets.get(i, 0)}
+            for i in range(10)
+        ]
+
+    outlier_runs = [r for r in run_list if r.get("is_outlier_run")]
+    sigma_flag = len(outlier_runs) > 0
+
+    detail["runs"] = run_list[:50]
+    detail["histogram"] = histogram
+    detail["sigma_flag"] = sigma_flag
+    detail["outlier_run_count"] = len(outlier_runs)
+    return detail

--- a/burnmap/templates/pages/prompts.html
+++ b/burnmap/templates/pages/prompts.html
@@ -1,0 +1,301 @@
+{# prompts.html — prompt list with search/sort, detail page with histogram and outlier flags #}
+{% extends "base.html" %}
+
+{% block title %}Prompts — burnmap{% endblock %}
+
+{% block content %}
+<div x-data="promptsPage()" x-init="load()">
+
+  <!-- List view -->
+  <template x-if="!selectedFp">
+    <div>
+      <div class="page-header">
+        <h1 class="page-title">Prompts</h1>
+        <span class="meta" style="font-size:12px;color:var(--ink-3)">search · sort · detail</span>
+      </div>
+
+      <!-- Search + sort controls -->
+      <div class="row" style="margin-bottom:14px;gap:8px;flex-wrap:wrap">
+        <input class="search-input"
+               type="search"
+               placeholder="Search prompt text…"
+               x-model="search"
+               @input.debounce.300ms="load()"/>
+        <select class="sort-select" x-model="sort" @change="load()">
+          <option value="cost">Sort: Cost</option>
+          <option value="runs">Sort: Runs</option>
+          <option value="tokens">Sort: Tokens</option>
+          <option value="recent">Sort: Recent</option>
+        </select>
+        <span class="spacer"></span>
+        <span class="mono muted" style="font-size:11px;align-self:center"
+              x-text="count + ' prompts'"></span>
+      </div>
+
+      <template x-if="loading">
+        <div class="loading-row">Loading…</div>
+      </template>
+
+      <template x-if="!loading && rows.length === 0">
+        <div class="loading-row">No prompts found.</div>
+      </template>
+
+      <template x-if="!loading && rows.length > 0">
+        <div class="card" style="overflow-x:auto">
+          <table class="t">
+            <thead>
+              <tr>
+                <th>Prompt</th>
+                <th>Agent</th>
+                <th class="right">Runs</th>
+                <th class="right">Tokens</th>
+                <th class="right">Cost</th>
+                <th>Last seen</th>
+                <th>Flag</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template x-for="p in rows" :key="p.fingerprint">
+                <tr @click="openDetail(p.fingerprint)" style="cursor:pointer">
+                  <td style="max-width:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">
+                    <span class="mono" style="font-size:11px" x-text="p.snippet || '(no text)'"></span>
+                  </td>
+                  <td>
+                    <span class="agent-badge"
+                          :class="p.agent ? 'agent-badge--' + p.agent.replace('_', '-') : ''"
+                          x-text="p.agent || '—'"></span>
+                  </td>
+                  <td class="num right" x-text="(p.run_count || 0).toLocaleString()"></td>
+                  <td class="num right" x-text="fmtTok(p.total_tokens)"></td>
+                  <td class="num right mono" x-text="'$' + (p.total_cost || 0).toFixed(4)"></td>
+                  <td class="mono muted" style="font-size:11px" x-text="fmtTime(p.last_seen)"></td>
+                  <td>
+                    <template x-if="p.is_outlier">
+                      <span class="chip chip--outlier" title="≥1 outlier run (2σ)">2σ</span>
+                    </template>
+                    <template x-if="!p.is_outlier">
+                      <span class="mono muted">—</span>
+                    </template>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+      </template>
+    </div>
+  </template>
+
+  <!-- Detail view -->
+  <template x-if="selectedFp">
+    <div>
+      <div class="page-header">
+        <button class="back-btn" @click="closeDetail()">← Prompts</button>
+        <h1 class="page-title">Prompt detail</h1>
+        <template x-if="detail && detail.sigma_flag">
+          <span class="chip chip--outlier" style="margin-left:8px">2σ outlier</span>
+        </template>
+      </div>
+
+      <template x-if="detailLoading">
+        <div class="loading-row">Loading detail…</div>
+      </template>
+
+      <template x-if="!detailLoading && detail">
+        <div>
+          <!-- Prompt text card -->
+          <div class="card" style="margin-bottom:16px">
+            <div class="card-label">Prompt text</div>
+            <pre class="prompt-text" x-text="detail.content"></pre>
+          </div>
+
+          <!-- Stats row -->
+          <div class="row stats-row" style="margin-bottom:16px;gap:12px;flex-wrap:wrap">
+            <div class="stat-card">
+              <div class="stat-val" x-text="(detail.run_count || 0).toLocaleString()"></div>
+              <div class="stat-label">Runs</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-val" x-text="fmtTok(detail.total_tokens)"></div>
+              <div class="stat-label">Total tokens</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-val mono" x-text="'$' + (detail.total_cost || 0).toFixed(4)"></div>
+              <div class="stat-label">Total cost</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-val" x-text="detail.outlier_run_count || 0"></div>
+              <div class="stat-label">Outlier runs</div>
+            </div>
+          </div>
+
+          <!-- Cost histogram -->
+          <div class="card" style="margin-bottom:16px">
+            <div class="card-label">Per-run cost histogram</div>
+            <template x-if="detail.histogram && detail.histogram.length > 0">
+              <div class="histogram" style="display:flex;align-items:flex-end;gap:3px;height:80px;padding:8px 0">
+                <template x-for="(bucket, i) in detail.histogram" :key="i">
+                  <div style="display:flex;flex-direction:column;align-items:center;flex:1">
+                    <div class="histogram-bar"
+                         :style="'height:' + barHeight(bucket.count) + 'px; background: var(--accent);'"
+                         :title="'$' + bucket.bucket_start.toFixed(5) + ' — ' + bucket.count + ' runs'">
+                    </div>
+                    <div class="mono muted" style="font-size:9px;margin-top:2px"
+                         x-text="'$' + (bucket.bucket_start || 0).toFixed(4)"></div>
+                  </div>
+                </template>
+              </div>
+            </template>
+            <template x-if="!detail.histogram || detail.histogram.length === 0">
+              <div class="muted" style="padding:16px;font-size:12px">No histogram data.</div>
+            </template>
+          </div>
+
+          <!-- Runs table -->
+          <div class="card">
+            <div class="card-label">Recent runs</div>
+            <table class="t">
+              <thead>
+                <tr>
+                  <th>Timestamp</th>
+                  <th>Session</th>
+                  <th class="right">Tokens</th>
+                  <th class="right">Cost</th>
+                  <th>Outlier</th>
+                  <th>Trace</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-for="(run, i) in detail.runs" :key="i">
+                  <tr>
+                    <td class="mono muted" style="font-size:11px" x-text="fmtTime(run.ts)"></td>
+                    <td>
+                      <span class="mono" style="font-size:11px"
+                            x-text="run.session_id ? run.session_id.slice(0, 12) + '…' : '—'"></span>
+                    </td>
+                    <td class="num right" x-text="fmtTok(run.input_tokens)"></td>
+                    <td class="num right mono" x-text="'$' + (run.cost_usd || 0).toFixed(5)"></td>
+                    <td>
+                      <template x-if="run.is_outlier_run">
+                        <span class="chip chip--outlier">2σ</span>
+                      </template>
+                      <template x-if="!run.is_outlier_run">
+                        <span class="mono muted">—</span>
+                      </template>
+                    </td>
+                    <td>
+                      <template x-if="run.session_id">
+                        <a :href="'/trace/' + run.session_id" class="link" style="font-size:11px">→ trace</a>
+                      </template>
+                    </td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </template>
+    </div>
+  </template>
+
+</div>
+
+<style>
+.page-header    { display:flex; align-items:center; gap:12px; margin-bottom:20px; }
+.page-title     { font-size:20px; font-weight:600; }
+.loading-row    { padding:40px; text-align:center; color:var(--ink-3); }
+.search-input   { padding:6px 10px; border:1px solid var(--border); border-radius:6px; font-size:13px; background:var(--surface); color:var(--ink); }
+.sort-select    { padding:6px 10px; border:1px solid var(--border); border-radius:6px; font-size:13px; background:var(--surface); color:var(--ink); }
+.spacer         { flex:1; }
+.row            { display:flex; }
+.num            { font-family:var(--font-mono); font-size:12px; }
+.right          { text-align:right; }
+.muted          { color:var(--ink-3); }
+.mono           { font-family:var(--font-mono); }
+.card           { background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:16px; }
+.card-label     { font-size:11px; color:var(--ink-3); text-transform:uppercase; letter-spacing:.05em; margin-bottom:8px; }
+.agent-badge    { display:inline-block; padding:1px 6px; border-radius:4px; font-size:11px; font-family:var(--font-mono); background:var(--surface-2); color:var(--ink-2); }
+.agent-badge--claude-code { background:#dbeafe; color:#1e40af; }
+.agent-badge--codex       { background:#dcfce7; color:#14532d; }
+.agent-badge--aider       { background:#fce7f3; color:#831843; }
+.chip           { display:inline-block; padding:1px 7px; border-radius:4px; font-size:11px; font-family:var(--font-mono); }
+.chip--outlier  { background:#fee2e2; color:#991b1b; }
+.back-btn       { padding:4px 10px; border:1px solid var(--border); border-radius:6px; background:var(--surface); color:var(--ink); cursor:pointer; font-size:13px; }
+.back-btn:hover { background:var(--surface-2); }
+.prompt-text    { font-family:var(--font-mono); font-size:12px; white-space:pre-wrap; word-break:break-word; margin:0; color:var(--ink-2); max-height:200px; overflow-y:auto; }
+.stat-card      { background:var(--surface-2); border:1px solid var(--border); border-radius:8px; padding:12px 16px; min-width:100px; text-align:center; }
+.stat-val       { font-size:20px; font-weight:600; }
+.stat-label     { font-size:11px; color:var(--ink-3); margin-top:2px; }
+.histogram-bar  { min-height:2px; border-radius:2px 2px 0 0; width:100%; }
+.link           { color:var(--accent); text-decoration:none; }
+.link:hover     { text-decoration:underline; }
+</style>
+
+<script>
+function promptsPage() {
+  return {
+    rows: [],
+    count: 0,
+    loading: false,
+    search: '',
+    sort: 'cost',
+    selectedFp: null,
+    detail: null,
+    detailLoading: false,
+
+    async load() {
+      this.loading = true;
+      try {
+        let url = '/api/prompts?limit=200';
+        if (this.search) url += '&search=' + encodeURIComponent(this.search);
+        if (this.sort)   url += '&sort=' + encodeURIComponent(this.sort);
+        const r = await fetch(url);
+        const d = await r.json();
+        this.rows  = d.prompts || [];
+        this.count = d.count || 0;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async openDetail(fp) {
+      this.selectedFp = fp;
+      this.detail = null;
+      this.detailLoading = true;
+      try {
+        const r = await fetch('/api/prompts/' + fp);
+        this.detail = await r.json();
+      } finally {
+        this.detailLoading = false;
+      }
+    },
+
+    closeDetail() {
+      this.selectedFp = null;
+      this.detail = null;
+    },
+
+    barHeight(count) {
+      if (!this.detail || !this.detail.histogram) return 0;
+      const max = Math.max(...this.detail.histogram.map(b => b.count), 1);
+      return Math.round((count / max) * 60);
+    },
+
+    fmtTime(ms) {
+      if (!ms) return '—';
+      return new Date(ms).toLocaleString(undefined, {
+        month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      });
+    },
+
+    fmtTok(n) {
+      if (!n) return '0';
+      if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+      if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+      return String(n);
+    },
+  };
+}
+</script>
+{% endblock %}

--- a/tests/test_prompts_api.py
+++ b/tests/test_prompts_api.py
@@ -1,0 +1,140 @@
+"""Tests for burnmap.api.prompts — query_prompts + query_prompt_detail."""
+import sqlite3
+import uuid
+
+import pytest
+
+from burnmap.api.prompts import query_prompts, query_prompt_detail
+from burnmap.db.schema import init_db, init_content_db
+
+_FP_A = "fp_aaaa"
+_FP_B = "fp_bbbb"
+_SID = str(uuid.uuid4())
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    init_content_db(conn)
+    _seed(conn)
+    yield conn
+    conn.close()
+
+
+def _seed(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO sessions (id, agent, started_at, ended_at) VALUES (?,?,?,?)",
+        (_SID, "claude_code", 1_700_000_000_000, 1_700_000_100_000),
+    )
+    conn.executemany(
+        "INSERT INTO prompts (fingerprint, first_seen, last_seen, run_count, total_tokens, total_cost)"
+        " VALUES (?,?,?,?,?,?)",
+        [
+            (_FP_A, 1_700_000_000, 1_700_001_000, 5, 5000, 0.05),
+            (_FP_B, 1_700_000_500, 1_700_001_500, 2, 1000, 0.01),
+        ],
+    )
+    conn.execute(
+        "INSERT INTO prompt_content (fingerprint, content, stored_at) VALUES (?,?,?)",
+        (_FP_A, "Tell me about the weather in Paris", 1_700_000_000),
+    )
+    conn.executemany(
+        "INSERT INTO prompt_runs (id, fingerprint, session_id, ts, input_tokens, cost_usd)"
+        " VALUES (?,?,?,?,?,?)",
+        [
+            (str(uuid.uuid4()), _FP_A, _SID, 1_700_000_001, 500, 0.005),
+            (str(uuid.uuid4()), _FP_A, _SID, 1_700_000_002, 600, 0.006),
+            (str(uuid.uuid4()), _FP_B, _SID, 1_700_000_003, 400, 0.004),
+        ],
+    )
+    conn.commit()
+
+
+class TestQueryPrompts:
+    def test_returns_all_prompts(self, db):
+        rows = query_prompts(db)
+        assert len(rows) == 2
+
+    def test_sort_by_cost(self, db):
+        rows = query_prompts(db, sort="cost")
+        assert rows[0]["fingerprint"] == _FP_A  # higher cost first
+
+    def test_sort_by_runs(self, db):
+        rows = query_prompts(db, sort="runs")
+        assert rows[0]["fingerprint"] == _FP_A  # more runs first
+
+    def test_sort_by_tokens(self, db):
+        rows = query_prompts(db, sort="tokens")
+        assert rows[0]["fingerprint"] == _FP_A  # more tokens first
+
+    def test_sort_by_recent(self, db):
+        rows = query_prompts(db, sort="recent")
+        assert rows[0]["fingerprint"] == _FP_B  # later last_seen first
+
+    def test_invalid_sort_defaults_to_cost(self, db):
+        rows = query_prompts(db, sort="invalid")
+        assert len(rows) == 2  # no crash
+
+    def test_limit(self, db):
+        rows = query_prompts(db, limit=1)
+        assert len(rows) == 1
+
+    def test_prompt_fields(self, db):
+        rows = query_prompts(db, sort="cost")
+        row = rows[0]
+        assert "fingerprint" in row
+        assert "run_count" in row
+        assert "total_tokens" in row
+        assert "total_cost" in row
+        assert "is_outlier" in row
+        assert "snippet" in row
+
+    def test_search_by_content(self, db):
+        rows = query_prompts(db, search="weather")
+        # FP_A has matching content
+        fps = [r["fingerprint"] for r in rows]
+        assert _FP_A in fps
+
+    def test_search_no_match(self, db):
+        rows = query_prompts(db, search="zzznonexistent")
+        assert rows == []
+
+
+class TestQueryPromptDetail:
+    def test_returns_detail_for_known_fp(self, db):
+        detail = query_prompt_detail(db, fingerprint=_FP_A)
+        assert detail is not None
+        assert detail["fingerprint"] == _FP_A
+
+    def test_returns_none_for_unknown_fp(self, db):
+        result = query_prompt_detail(db, fingerprint="nonexistent")
+        assert result is None
+
+    def test_detail_has_runs(self, db):
+        detail = query_prompt_detail(db, fingerprint=_FP_A)
+        assert "runs" in detail
+        assert len(detail["runs"]) >= 2
+
+    def test_detail_has_histogram(self, db):
+        detail = query_prompt_detail(db, fingerprint=_FP_A)
+        assert "histogram" in detail
+        assert isinstance(detail["histogram"], list)
+
+    def test_histogram_structure(self, db):
+        detail = query_prompt_detail(db, fingerprint=_FP_A)
+        if detail["histogram"]:
+            bucket = detail["histogram"][0]
+            assert "bucket_start" in bucket
+            assert "count" in bucket
+
+    def test_sigma_flag_false_when_no_outliers(self, db):
+        detail = query_prompt_detail(db, fingerprint=_FP_A)
+        assert "sigma_flag" in detail
+        # No is_outlier spans seeded, so false
+        assert detail["sigma_flag"] is False
+
+    def test_detail_has_content(self, db):
+        detail = query_prompt_detail(db, fingerprint=_FP_A)
+        assert "content" in detail


### PR DESCRIPTION
Closes #17

## Summary
Searchable, sortable prompts list with agent badges + detail page with per-run cost histogram, outlier sigma flags, and trace links.

## Tests
- 17 new tests for query_prompts + query_prompt_detail
- All 275 existing tests pass

## Acceptance Criteria
- [x] Searchable prompt list with agent badges
- [x] Sort by cost/runs/tokens/recent
- [x] Detail page with histogram
- [x] Outlier sigma flags
- [x] Link to trace view