### PR TITLE
feat: API routes — overview, register all routers, agent filter

### DIFF
--- a/burnmap/api/__init__.py
+++ b/burnmap/api/__init__.py
@@ -6,5 +6,10 @@ from .tools import router as tools_router
 from .sessions import router as sessions_router
 from .settings import router as settings_router
 from .prompts import router as prompts_router
+from .overview import router as overview_router
 
-__all__ = ["tasks_router", "providers_router", "quota_router", "trace_router", "tools_router", "sessions_router", "settings_router", "prompts_router"]
+__all__ = [
+    "tasks_router", "providers_router", "quota_router", "trace_router",
+    "tools_router", "sessions_router", "settings_router", "prompts_router",
+    "overview_router",
+]

--- a/burnmap/api/overview.py
+++ b/burnmap/api/overview.py
@@ -1,0 +1,92 @@
+"""/api/overview — top-level dashboard summary stats."""
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends, Query
+    from fastapi.responses import JSONResponse
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/overview")
+    def get_overview(
+        agent: str | None = Query(None, description="Filter by agent name"),
+        db: sqlite3.Connection = Depends(_db),
+    ) -> JSONResponse:
+        return JSONResponse(query_overview(db, agent=agent))
+
+else:
+    router = None  # type: ignore[assignment]
+
+
+def query_overview(
+    conn: sqlite3.Connection,
+    *,
+    agent: str | None = None,
+) -> dict[str, Any]:
+    """Return top-level summary: session count, turn count, total tokens, total cost."""
+    agent_clause = ""
+    params: list[Any] = []
+    if agent:
+        agent_clause = "WHERE agent = ?"
+        params.append(agent)
+
+    row = conn.execute(
+        f"""
+        SELECT
+            COUNT(DISTINCT id)              AS session_count,
+            MIN(started_at)                 AS first_seen_ms,
+            MAX(CASE WHEN ended_at > 0 THEN ended_at ELSE started_at END) AS last_seen_ms
+        FROM sessions
+        {agent_clause}
+        """,
+        params,
+    ).fetchone()
+    session_count = row["session_count"] if row else 0
+    first_seen_ms = row["first_seen_ms"] if row else None
+    last_seen_ms = row["last_seen_ms"] if row else None
+
+    turn_clause = ""
+    turn_params: list[Any] = []
+    if agent:
+        turn_clause = "WHERE agent = ?"
+        turn_params.append(agent)
+
+    turn_row = conn.execute(
+        f"""
+        SELECT
+            COUNT(*)            AS turn_count,
+            SUM(input_tokens)   AS total_input_tokens,
+            SUM(output_tokens)  AS total_output_tokens,
+            SUM(cost_usd)       AS total_cost_usd
+        FROM turns
+        {turn_clause}
+        """,
+        turn_params,
+    ).fetchone()
+
+    return {
+        "session_count": session_count,
+        "turn_count": int(turn_row["turn_count"] or 0) if turn_row else 0,
+        "total_input_tokens": int(turn_row["total_input_tokens"] or 0) if turn_row else 0,
+        "total_output_tokens": int(turn_row["total_output_tokens"] or 0) if turn_row else 0,
+        "total_cost_usd": float(turn_row["total_cost_usd"] or 0.0) if turn_row else 0.0,
+        "first_seen_ms": first_seen_ms,
+        "last_seen_ms": last_seen_ms,
+    }

--- a/burnmap/api/prompts.py
+++ b/burnmap/api/prompts.py
@@ -28,10 +28,11 @@ if _FASTAPI:
     def list_prompts(
         search: str | None = Query(None, description="Filter by prompt text substring"),
         sort: str | None = Query("cost", description="Sort by: cost|runs|tokens|recent"),
+        agent: str | None = Query(None, description="Filter by agent name"),
         limit: int = Query(100, ge=1, le=1000),
         db: sqlite3.Connection = Depends(_db),
     ) -> JSONResponse:
-        rows = query_prompts(db, search=search, sort=sort, limit=limit)
+        rows = query_prompts(db, search=search, sort=sort, agent=agent, limit=limit)
         return JSONResponse({"prompts": rows, "count": len(rows)})
 
     @router.get("/api/prompts/{fingerprint}")
@@ -57,6 +58,7 @@ def query_prompts(
     *,
     search: str | None = None,
     sort: str | None = "cost",
+    agent: str | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     """Return prompt list rows with agent badges and outlier flag."""
@@ -75,6 +77,10 @@ def query_prompts(
     if search:
         where_clauses.append("(pc.content LIKE ? OR p.fingerprint LIKE ?)")
         params.extend([f"%{search}%", f"%{search}%"])
+
+    if agent:
+        where_clauses.append("s.agent = ?")
+        params.append(agent)
 
     where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
 

--- a/burnmap/api/tasks.py
+++ b/burnmap/api/tasks.py
@@ -27,10 +27,11 @@ if _FASTAPI:
     @router.get("/api/tasks")
     def list_tasks(
         kind: str | None = Query(None, description="Filter by kind: slash|skill|subagent"),
+        agent: str | None = Query(None, description="Filter by agent name"),
         limit: int = Query(100, ge=1, le=1000),
         db: sqlite3.Connection = Depends(_db),
     ) -> JSONResponse:
-        rows = query_tasks(db, kind=kind, limit=limit)
+        rows = query_tasks(db, kind=kind, agent=agent, limit=limit)
         return JSONResponse({"tasks": rows})
 else:
     router = None  # type: ignore[assignment]
@@ -45,6 +46,7 @@ def query_tasks(
     conn: sqlite3.Connection,
     *,
     kind: str | None = None,
+    agent: str | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
     """Return aggregated task rows from the spans table.
@@ -65,6 +67,10 @@ def query_tasks(
         placeholders = ",".join("?" * len(_VALID_KINDS))
         where = f"WHERE kind IN ({placeholders})"
         params.extend(sorted(_VALID_KINDS))
+
+    if agent is not None:
+        where += " AND agent = ?"
+        params.append(agent)
 
     sql = f"""
         SELECT

--- a/burnmap/api/tools.py
+++ b/burnmap/api/tools.py
@@ -26,19 +26,31 @@ if _FASTAPI:
 
     @router.get("/api/tools")
     def list_tools(
+        agent: str | None = Query(None, description="Filter by agent name"),
         limit: int = Query(100, ge=1, le=1000),
         db: sqlite3.Connection = Depends(_db),
     ) -> JSONResponse:
-        rows = query_tools(db, limit=limit)
+        rows = query_tools(db, agent=agent, limit=limit)
         return JSONResponse({"tools": rows})
 else:
     router = None  # type: ignore[assignment]
 
 
-def query_tools(conn: sqlite3.Connection, *, limit: int = 100) -> list[dict[str, Any]]:
+def query_tools(
+    conn: sqlite3.Connection,
+    *,
+    agent: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
     """Return per-tool aggregate rows (kind='tool'), ordered by total_cost_usd desc."""
+    params: list[Any] = []
+    agent_clause = ""
+    if agent:
+        agent_clause = "AND agent = ?"
+        params.append(agent)
+    params.append(limit)
     cur = conn.execute(
-        """
+        f"""
         SELECT
             name,
             COUNT(*)                                        AS calls,
@@ -50,12 +62,12 @@ def query_tools(conn: sqlite3.Connection, *, limit: int = 100) -> list[dict[str,
             SUM(cost_usd)                                   AS total_cost_usd,
             MAX(started_at)                                 AS last_seen_ms
         FROM spans
-        WHERE kind = 'tool'
+        WHERE kind = 'tool' {agent_clause}
         GROUP BY name
         ORDER BY total_cost_usd DESC
         LIMIT ?
         """,
-        (limit,),
+        params,
     )
     rows = [dict(r) for r in cur.fetchall()]
     # Compute share of total cost

--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -10,7 +10,11 @@ from fastapi.templating import Jinja2Templates
 from pathlib import Path
 
 from burnmap.auth import TokenAuthMiddleware
-from burnmap.api import tasks_router, providers_router
+from burnmap.api import (
+    tasks_router, providers_router, quota_router, trace_router,
+    tools_router, sessions_router, settings_router, prompts_router,
+    overview_router,
+)
 from burnmap.api.events import router as events_router
 from burnmap.watcher import Watcher
 
@@ -54,8 +58,13 @@ def create_app() -> FastAPI:
     if TokenAuthMiddleware is not None:
         app.add_middleware(TokenAuthMiddleware)
 
-    app.include_router(tasks_router)
-    app.include_router(providers_router)
+    for router in (
+        overview_router, tasks_router, providers_router, quota_router,
+        trace_router, tools_router, sessions_router, settings_router,
+        prompts_router,
+    ):
+        if router is not None:
+            app.include_router(router)
     app.include_router(events_router)
 
     # Optional routers (only available if imported)

--- a/tests/test_overview_api.py
+++ b/tests/test_overview_api.py
@@ -1,0 +1,86 @@
+"""Tests for burnmap.api.overview — query_overview."""
+import sqlite3
+import uuid
+
+import pytest
+
+from burnmap.api.overview import query_overview
+from burnmap.db.schema import init_db
+
+_SID_A = str(uuid.uuid4())
+_SID_B = str(uuid.uuid4())
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    _seed(conn)
+    yield conn
+    conn.close()
+
+
+def _seed(conn: sqlite3.Connection) -> None:
+    conn.executemany(
+        "INSERT INTO sessions (id, agent, started_at, ended_at) VALUES (?,?,?,?)",
+        [
+            (_SID_A, "claude_code", 1_700_000_000_000, 1_700_001_000_000),
+            (_SID_B, "codex",       1_700_002_000_000, 1_700_003_000_000),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO turns (id, session_id, agent, role, input_tokens, output_tokens, cost_usd, ts)"
+        " VALUES (?,?,?,?,?,?,?,?)",
+        [
+            (str(uuid.uuid4()), _SID_A, "claude_code", "user",      500, 0,   0.005, 1_700_000_100_000),
+            (str(uuid.uuid4()), _SID_A, "claude_code", "assistant",   0, 200, 0.010, 1_700_000_200_000),
+            (str(uuid.uuid4()), _SID_B, "codex",       "user",      300, 0,   0.003, 1_700_002_100_000),
+        ],
+    )
+    conn.commit()
+
+
+class TestQueryOverview:
+    def test_session_count(self, db):
+        result = query_overview(db)
+        assert result["session_count"] == 2
+
+    def test_turn_count(self, db):
+        result = query_overview(db)
+        assert result["turn_count"] == 3
+
+    def test_total_tokens(self, db):
+        result = query_overview(db)
+        assert result["total_input_tokens"] == 800
+        assert result["total_output_tokens"] == 200
+
+    def test_total_cost(self, db):
+        result = query_overview(db)
+        assert abs(result["total_cost_usd"] - 0.018) < 1e-6
+
+    def test_first_last_seen(self, db):
+        result = query_overview(db)
+        assert result["first_seen_ms"] == 1_700_000_000_000
+        assert result["last_seen_ms"] == 1_700_003_000_000
+
+    def test_agent_filter(self, db):
+        result = query_overview(db, agent="claude_code")
+        assert result["session_count"] == 1
+        assert result["turn_count"] == 2
+        assert result["total_input_tokens"] == 500
+
+    def test_agent_filter_no_match(self, db):
+        result = query_overview(db, agent="unknown_agent")
+        assert result["session_count"] == 0
+        assert result["turn_count"] == 0
+        assert result["total_cost_usd"] == 0.0
+
+    def test_empty_db(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        init_db(conn)
+        result = query_overview(conn)
+        assert result["session_count"] == 0
+        assert result["turn_count"] == 0
+        conn.close()

--- a/tests/test_prompts_api.py
+++ b/tests/test_prompts_api.py
@@ -101,6 +101,14 @@ class TestQueryPrompts:
         rows = query_prompts(db, search="zzznonexistent")
         assert rows == []
 
+    def test_agent_filter_match(self, db):
+        rows = query_prompts(db, agent="claude_code")
+        assert len(rows) == 2
+
+    def test_agent_filter_no_match(self, db):
+        rows = query_prompts(db, agent="codex")
+        assert rows == []
+
 
 class TestQueryPromptDetail:
     def test_returns_detail_for_known_fp(self, db):

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -28,6 +28,8 @@ def _seed(conn: sqlite3.Connection) -> None:
         ("s5", "sess-c", "claude_code", "skill",   "battle-qa",   900, 250, 0.015, 1_700_000_004_000),
         # "tool" kind — should NOT appear in tasks results
         ("s6", "sess-c", "claude_code", "tool",    "Read",         0,   0, 0.0,   1_700_000_005_000),
+        # different agent
+        ("s7", "sess-d", "codex",       "slash",   "/commit",     400, 100, 0.006, 1_700_000_006_000),
     ]
     conn.executemany(
         "INSERT INTO spans (id, session_id, agent, kind, name, input_tokens, output_tokens, cost_usd, started_at) VALUES (?,?,?,?,?,?,?,?,?)", rows
@@ -45,29 +47,30 @@ class TestQueryTasks:
     def test_aggregates_calls(self, db):
         rows = query_tasks(db)
         commit_row = next(r for r in rows if r["name"] == "/commit")
-        assert commit_row["calls"] == 2
+        # s1, s2 (claude_code) + s7 (codex) = 3 calls
+        assert commit_row["calls"] == 3
 
     def test_token_sums(self, db):
         rows = query_tasks(db)
         commit_row = next(r for r in rows if r["name"] == "/commit")
-        assert commit_row["total_input_tokens"] == 1400
-        assert commit_row["total_output_tokens"] == 350
+        assert commit_row["total_input_tokens"] == 1800
+        assert commit_row["total_output_tokens"] == 450
 
     def test_avg_tokens_per_call(self, db):
         rows = query_tasks(db)
         commit_row = next(r for r in rows if r["name"] == "/commit")
-        # (800+200+600+150) / 2 = 875
-        assert commit_row["avg_tokens_per_call"] == pytest.approx(875.0)
+        # (800+200+600+150+400+100) / 3 = 750
+        assert commit_row["avg_tokens_per_call"] == pytest.approx(750.0)
 
     def test_cost_sum(self, db):
         rows = query_tasks(db)
         commit_row = next(r for r in rows if r["name"] == "/commit")
-        assert commit_row["total_cost_usd"] == pytest.approx(0.021)
+        assert commit_row["total_cost_usd"] == pytest.approx(0.027)
 
     def test_last_seen_ms(self, db):
         rows = query_tasks(db)
         commit_row = next(r for r in rows if r["name"] == "/commit")
-        assert commit_row["last_seen_ms"] == 1_700_000_001_000
+        assert commit_row["last_seen_ms"] == 1_700_000_006_000
 
     def test_ordered_by_cost_desc(self, db):
         rows = query_tasks(db)
@@ -98,6 +101,15 @@ class TestQueryTasks:
     def test_limit_respected(self, db):
         rows = query_tasks(db, limit=1)
         assert len(rows) == 1
+
+    def test_agent_filter(self, db):
+        rows = query_tasks(db, agent="codex")
+        assert len(rows) == 1
+        assert rows[0]["name"] == "/commit"
+
+    def test_agent_filter_no_match(self, db):
+        rows = query_tasks(db, agent="unknown_agent")
+        assert rows == []
 
     def test_empty_db(self, db):
         """Empty spans table returns empty list, not an error."""

--- a/tests/test_tools_api.py
+++ b/tests/test_tools_api.py
@@ -25,6 +25,8 @@ def _seed(conn: sqlite3.Connection) -> None:
         ("t3", "sess-a", "claude_code", "tool", "Write",  50, 0, 0.005, 1_700_000_002_000),
         # non-tool kind — must NOT appear
         ("t4", "sess-a", "claude_code", "slash", "/commit", 400, 100, 0.010, 1_700_000_003_000),
+        # different agent
+        ("t5", "sess-b", "codex", "tool", "Read", 80, 0, 0.001, 1_700_000_004_000),
     ]
     conn.executemany(
         "INSERT INTO spans (id, session_id, agent, kind, name, input_tokens, output_tokens, cost_usd, started_at)"
@@ -46,18 +48,19 @@ class TestQueryTools:
     def test_aggregates_calls(self, db):
         rows = query_tools(db)
         read_row = next(r for r in rows if r["name"] == "Read")
-        assert read_row["calls"] == 2
+        # t1, t2 (claude_code) + t5 (codex) = 3 calls
+        assert read_row["calls"] == 3
 
     def test_token_sums(self, db):
         rows = query_tools(db)
         read_row = next(r for r in rows if r["name"] == "Read")
-        assert read_row["total_input_tokens"] == 300
+        assert read_row["total_input_tokens"] == 380
         assert read_row["total_output_tokens"] == 0
 
     def test_cost_sum(self, db):
         rows = query_tools(db)
         read_row = next(r for r in rows if r["name"] == "Read")
-        assert abs(read_row["total_cost_usd"] - 0.003) < 1e-9
+        assert abs(read_row["total_cost_usd"] - 0.004) < 1e-9
 
     def test_ordered_by_cost_desc(self, db):
         rows = query_tools(db)
@@ -72,6 +75,16 @@ class TestQueryTools:
     def test_limit(self, db):
         rows = query_tools(db, limit=1)
         assert len(rows) == 1
+
+    def test_agent_filter(self, db):
+        rows = query_tools(db, agent="codex")
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Read"
+        assert rows[0]["calls"] == 1
+
+    def test_agent_filter_no_match(self, db):
+        rows = query_tools(db, agent="unknown_agent")
+        assert rows == []
 
     def test_empty_db(self):
         conn = sqlite3.connect(":memory:")


### PR DESCRIPTION
## Summary

- Add `GET /api/overview` endpoint with `agent=` filter returning session count, turn count, token totals, and cost summary
- Register all previously-defined but unmounted routers in `app.py` (`/api/quota`, `/api/traces/:id`, `/api/tools`, `/api/sessions`, `/api/settings`, `/api/prompts`)
- Add `agent=` query param to `/api/tools` and `/api/tasks` list endpoints (all list endpoints now support agent filter)
- 8 new tests for overview + agent filter coverage; full suite 287 passed

Closes #13