### PR TITLE
feat: backfill — ingest all pre-existing JSONL on first run

### DIFF
--- a/burnmap/api/backfill.py
+++ b/burnmap/api/backfill.py
@@ -1,0 +1,194 @@
+"""/api/backfill — ingest all pre-existing JSONL/log files on first run."""
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+from typing import Any
+
+try:
+    from fastapi import APIRouter, Depends
+    from fastapi.responses import JSONResponse
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+from burnmap.db.schema import get_db
+
+if _FASTAPI:
+    router = APIRouter()
+
+    def _db() -> sqlite3.Connection:  # pragma: no cover
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    @router.get("/api/backfill")
+    def backfill_status(db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
+        """Return backfill progress: done/total/pct."""
+        return JSONResponse(query_backfill_status(db))
+
+    @router.post("/api/backfill/run")
+    def backfill_run(db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
+        """Trigger synchronous backfill ingestion. Idempotent."""
+        result = run_backfill(db)
+        return JSONResponse(result)
+
+else:
+    router = None  # type: ignore[assignment]
+
+
+# ── File discovery ────────────────────────────────────────────────────────────
+
+_ADAPTER_PATHS: dict[str, list[Path]] = {
+    "claude_code": [
+        Path.home() / ".claude" / "projects",
+        Path.home() / "Library" / "Application Support" / "Claude",
+    ],
+    "codex": [
+        Path.home() / ".codex",
+        Path.home() / ".local" / "share" / "codex",
+    ],
+    "cline": [
+        Path.home() / ".cline",
+        Path.home() / "Library" / "Application Support" / "Code" / "User"
+        / "globalStorage" / "saoudrizwan.claude-dev",
+    ],
+    "aider": [
+        Path.home() / ".aider",
+        Path.home() / ".local" / "share" / "aider",
+    ],
+}
+
+_LOG_EXTENSIONS = {".jsonl", ".json", ".log", ".md"}
+
+
+def _discover_files() -> list[tuple[str, Path]]:
+    """Return (agent, path) pairs for all discoverable log files."""
+    found: list[tuple[str, Path]] = []
+    for agent, dirs in _ADAPTER_PATHS.items():
+        for d in dirs:
+            if d.is_dir():
+                for p in d.rglob("*"):
+                    if p.is_file() and p.suffix in _LOG_EXTENSIONS:
+                        found.append((agent, p))
+    return found
+
+
+# ── First-run detection ───────────────────────────────────────────────────────
+
+def is_first_run(conn: sqlite3.Connection) -> bool:
+    """Return True if the sessions table is empty (no data ingested yet)."""
+    row = conn.execute("SELECT COUNT(*) AS n FROM sessions").fetchone()
+    return (row["n"] if row else 0) == 0
+
+
+# ── Ingestion ─────────────────────────────────────────────────────────────────
+
+def _ingest_jsonl_file(conn: sqlite3.Connection, agent: str, path: Path) -> int:
+    """Parse a JSONL file and insert sessions/spans. Return spans inserted."""
+    import json
+
+    existing_sessions: set[str] = {
+        row[0] for row in conn.execute("SELECT id FROM sessions")
+    }
+
+    inserted = 0
+    session_ids_seen: set[str] = set()
+
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            # Extract session id from common field names
+            session_id = (
+                record.get("sessionId")
+                or record.get("session_id")
+                or str(path)  # fallback: file path as session id
+            )
+
+            # Ensure session row exists (dedup)
+            if session_id not in existing_sessions and session_id not in session_ids_seen:
+                conn.execute(
+                    "INSERT OR IGNORE INTO sessions (id, agent, started_at, ended_at) VALUES (?,?,0,0)",
+                    (session_id, agent),
+                )
+                session_ids_seen.add(session_id)
+
+            # Only insert turn spans for assistant messages with usage
+            msg = record.get("message", {})
+            usage = msg.get("usage") or record.get("usage") or {}
+            if not usage:
+                continue
+
+            span_id = record.get("uuid") or record.get("id") or str(uuid.uuid4())
+            input_tokens = int(usage.get("input_tokens") or 0)
+            output_tokens = int(usage.get("output_tokens") or 0)
+            cost = float(record.get("costUSD") or record.get("cost_usd") or 0.0)
+
+            conn.execute(
+                """INSERT OR IGNORE INTO spans
+                   (id, session_id, agent, kind, name,
+                    input_tokens, output_tokens, cost_usd, started_at, ended_at)
+                   VALUES (?,?,?,?,?,?,?,?,0,0)""",
+                (span_id, session_id, agent, "turn", "turn", input_tokens, output_tokens, cost),
+            )
+            inserted += 1
+
+    conn.commit()
+    return inserted
+
+
+def run_backfill(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Ingest all adapter log files. Skip already-ingested sessions. Idempotent."""
+    files = _discover_files()
+    total = len(files)
+    done = 0
+    spans_added = 0
+
+    for agent, path in files:
+        if path.suffix == ".jsonl":
+            spans_added += _ingest_jsonl_file(conn, agent, path)
+        done += 1
+
+    row = conn.execute(
+        "SELECT COUNT(DISTINCT session_id) AS s, COUNT(*) AS sp FROM spans"
+    ).fetchone()
+    return {
+        "files_processed": done,
+        "files_total": total,
+        "spans_added": spans_added,
+        "sessions_ingested": row["s"] if row else 0,
+        "spans_ingested": row["sp"] if row else 0,
+        "pct": 100 if total == 0 else round(done / total * 100),
+    }
+
+
+# ── Status (read-only) ────────────────────────────────────────────────────────
+
+def query_backfill_status(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Return current ingestion counts and file discovery totals."""
+    row = conn.execute(
+        "SELECT COUNT(DISTINCT session_id) AS s, COUNT(*) AS sp FROM spans"
+    ).fetchone()
+    sessions = row["s"] if row else 0
+    spans = row["sp"] if row else 0
+    total_files = len(_discover_files())
+    pct = 100 if total_files == 0 else min(100, round(sessions / total_files * 100))
+    return {
+        "done": sessions,
+        "total": total_files,
+        "pct": pct,
+        "sessions_ingested": sessions,
+        "spans_ingested": spans,
+        "first_run": is_first_run(conn),
+    }

--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -80,6 +80,13 @@ def create_app() -> FastAPI:
     except ImportError:
         pass
 
+    try:
+        from burnmap.api.backfill import router as backfill_router
+        if backfill_router is not None:
+            app.include_router(backfill_router)
+    except ImportError:
+        pass
+
     static_dir = Path(__file__).parent / "static"
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,191 @@
+"""Tests for backfill ingestion — first-run detection, ingest, dedup, progress."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from burnmap.api.backfill import (
+    is_first_run,
+    run_backfill,
+    query_backfill_status,
+    _ingest_jsonl_file,
+    _discover_files,
+    _ADAPTER_PATHS,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def conn(tmp_path):
+    db = sqlite3.connect(str(tmp_path / "test.db"))
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            agent TEXT NOT NULL,
+            started_at INTEGER DEFAULT 0,
+            ended_at INTEGER DEFAULT 0
+        );
+        CREATE TABLE spans (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            agent TEXT NOT NULL,
+            kind TEXT NOT NULL DEFAULT 'turn',
+            name TEXT NOT NULL DEFAULT 'turn',
+            parent_id TEXT,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0.0,
+            started_at INTEGER DEFAULT 0,
+            ended_at INTEGER DEFAULT 0,
+            is_outlier INTEGER DEFAULT 0
+        );
+    """)
+    return db
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    with open(path, "w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+    return path
+
+
+def _make_turn(session_id: str, uid: str | None = None, input_tokens: int = 100) -> dict:
+    return {
+        "uuid": uid or str(uuid.uuid4()),
+        "sessionId": session_id,
+        "message": {
+            "role": "assistant",
+            "usage": {"input_tokens": input_tokens, "output_tokens": 50},
+        },
+        "costUSD": 0.01,
+    }
+
+
+# ── First-run detection ───────────────────────────────────────────────────────
+
+class TestIsFirstRun:
+    def test_empty_sessions_is_first_run(self, conn):
+        assert is_first_run(conn) is True
+
+    def test_non_empty_sessions_not_first_run(self, conn):
+        conn.execute("INSERT INTO sessions (id, agent) VALUES ('s1', 'claude_code')")
+        conn.commit()
+        assert is_first_run(conn) is False
+
+
+# ── JSONL ingestion ───────────────────────────────────────────────────────────
+
+class TestIngestJsonlFile:
+    def test_inserts_spans(self, conn, tmp_path):
+        f = _write_jsonl(tmp_path / "sess.jsonl", [
+            _make_turn("sess-1"),
+            _make_turn("sess-1"),
+        ])
+        count = _ingest_jsonl_file(conn, "claude_code", f)
+        assert count == 2
+
+    def test_creates_session_row(self, conn, tmp_path):
+        f = _write_jsonl(tmp_path / "sess.jsonl", [_make_turn("sess-x")])
+        _ingest_jsonl_file(conn, "claude_code", f)
+        row = conn.execute("SELECT id FROM sessions WHERE id='sess-x'").fetchone()
+        assert row is not None
+
+    def test_dedup_skips_existing_session_spans(self, conn, tmp_path):
+        uid = str(uuid.uuid4())
+        turn = _make_turn("sess-dup", uid=uid)
+        f = _write_jsonl(tmp_path / "sess.jsonl", [turn])
+        # First ingest
+        _ingest_jsonl_file(conn, "claude_code", f)
+        # Second ingest — same file, same span id
+        count2 = _ingest_jsonl_file(conn, "claude_code", f)
+        assert count2 == 1  # INSERT OR IGNORE — no duplicates in DB
+        total = conn.execute("SELECT COUNT(*) AS n FROM spans").fetchone()["n"]
+        assert total == 1
+
+    def test_skips_lines_without_usage(self, conn, tmp_path):
+        records = [
+            {"uuid": "u1", "sessionId": "s1", "message": {"role": "user"}},
+            _make_turn("s1"),
+        ]
+        f = _write_jsonl(tmp_path / "sess.jsonl", records)
+        count = _ingest_jsonl_file(conn, "claude_code", f)
+        assert count == 1
+
+    def test_skips_invalid_json_lines(self, conn, tmp_path):
+        p = tmp_path / "bad.jsonl"
+        p.write_text('{"valid": 1, "sessionId": "s1", "message": {"usage": {"input_tokens": 10, "output_tokens": 5}}}\nnot-json\n')
+        count = _ingest_jsonl_file(conn, "claude_code", p)
+        assert count == 1
+
+
+# ── run_backfill ──────────────────────────────────────────────────────────────
+
+class TestRunBackfill:
+    def test_returns_expected_keys(self, conn, monkeypatch):
+        import burnmap.api.backfill as mod
+        monkeypatch.setattr(mod, "_discover_files", lambda: [])
+        result = run_backfill(conn)
+        assert "files_processed" in result
+        assert "files_total" in result
+        assert "pct" in result
+        assert "sessions_ingested" in result
+        assert "spans_ingested" in result
+
+    def test_no_files_returns_100_pct(self, conn, monkeypatch):
+        import burnmap.api.backfill as mod
+        monkeypatch.setattr(mod, "_discover_files", lambda: [])
+        result = run_backfill(conn)
+        assert result["pct"] == 100
+        assert result["files_total"] == 0
+
+    def test_ingests_fixture_jsonl(self, conn, tmp_path, monkeypatch):
+        import burnmap.api.backfill as mod
+        f = _write_jsonl(tmp_path / "fixture.jsonl", [
+            _make_turn("sess-a"),
+            _make_turn("sess-b"),
+        ])
+        monkeypatch.setattr(mod, "_discover_files", lambda: [("claude_code", f)])
+        result = run_backfill(conn)
+        assert result["files_processed"] == 1
+        assert result["spans_added"] == 2
+
+    def test_idempotent_double_run(self, conn, tmp_path, monkeypatch):
+        import burnmap.api.backfill as mod
+        f = _write_jsonl(tmp_path / "fixture.jsonl", [_make_turn("sess-idem")])
+        monkeypatch.setattr(mod, "_discover_files", lambda: [("claude_code", f)])
+        run_backfill(conn)
+        run_backfill(conn)
+        total = conn.execute("SELECT COUNT(*) AS n FROM spans").fetchone()["n"]
+        assert total == 1  # dedup — no duplicates
+
+
+# ── query_backfill_status ─────────────────────────────────────────────────────
+
+class TestQueryBackfillStatus:
+    def test_returns_required_keys(self, conn, monkeypatch):
+        import burnmap.api.backfill as mod
+        monkeypatch.setattr(mod, "_discover_files", lambda: [])
+        result = query_backfill_status(conn)
+        for key in ("done", "total", "pct", "sessions_ingested", "spans_ingested", "first_run"):
+            assert key in result
+
+    def test_first_run_true_when_empty(self, conn, monkeypatch):
+        import burnmap.api.backfill as mod
+        monkeypatch.setattr(mod, "_discover_files", lambda: [])
+        result = query_backfill_status(conn)
+        assert result["first_run"] is True
+
+    def test_first_run_false_after_ingest(self, conn, monkeypatch, tmp_path):
+        import burnmap.api.backfill as mod
+        f = _write_jsonl(tmp_path / "f.jsonl", [_make_turn("s1")])
+        monkeypatch.setattr(mod, "_discover_files", lambda: [("claude_code", f)])
+        run_backfill(conn)
+        result = query_backfill_status(conn)
+        assert result["first_run"] is False


### PR DESCRIPTION
Closes #12

## What
Implements first-run backfill ingestion: scans all adapter log directories and ingests pre-existing JSONL session files into the database.

## Changes
- `burnmap/api/backfill.py` — `/api/backfill` GET (status) + `/api/backfill/run` POST (trigger ingestion)
- `burnmap/app.py` — register backfill router
- `tests/test_backfill.py` — 14 tests covering all acceptance criteria

## Acceptance Criteria
- [x] First-run detection (empty sessions table)
- [x] Sequential ingestion across all adapters
- [x] Progress endpoint: `/api/backfill` returns done/total/pct
- [x] Dedup: skip already-ingested sessions via INSERT OR IGNORE
- [x] Tests with fixture data

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>