### PR TITLE
feat: Codex CLI adapter — parse session JSONL

### DIFF
--- a/t01_burnmap/adapters/__init__.py
+++ b/t01_burnmap/adapters/__init__.py
@@ -1,5 +1,6 @@
 from .base import BaseAdapter
 from .cline import ClineAdapter
 from .registry import AdapterRegistry
+from .codex import CodexAdapter
 
-__all__ = ["BaseAdapter", "AdapterRegistry", "ClineAdapter"]
+__all__ = ["BaseAdapter", "AdapterRegistry", "ClineAdapter", "CodexAdapter"]

--- a/t01_burnmap/adapters/codex.py
+++ b/t01_burnmap/adapters/codex.py
@@ -1,0 +1,87 @@
+"""Codex CLI adapter — parses ~/.codex/sessions/ JSONL session logs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .base import BaseAdapter
+
+
+class CodexAdapter(BaseAdapter):
+    """Parses Codex CLI JSONL session files.
+
+    Each line is a JSON record. Dedup by ``id`` (turn_id).
+    Supports two record shapes:
+      v1 — flat: prompt_tokens / completion_tokens at top level
+      v2 — nested: usage.prompt_tokens / usage.completion_tokens
+    """
+
+    def default_paths(self) -> list[Path]:
+        return list(Path.home().glob(".codex/sessions/*.jsonl"))
+
+    def is_supported_file(self, path: Path) -> bool:
+        return path.suffix == ".jsonl"
+
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        """Return normalised turn records from a Codex JSONL session file."""
+        seen: set[str] = set()
+        turns: list[dict[str, Any]] = []
+
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if not isinstance(record, dict):
+                    continue
+
+                turn_id = record.get("id", "")
+                if not turn_id:
+                    continue
+                if turn_id in seen:
+                    continue
+                seen.add(turn_id)
+
+                # Token extraction: v2 nested usage, v1 flat
+                usage = record.get("usage") or {}
+                input_tokens = (
+                    usage.get("prompt_tokens")
+                    or record.get("prompt_tokens", 0)
+                )
+                output_tokens = (
+                    usage.get("completion_tokens")
+                    or record.get("completion_tokens", 0)
+                )
+                cache_read_tokens = usage.get("cached_tokens", 0)
+
+                # Tool calls (optional field in some Codex versions)
+                tool_uses: list[dict[str, Any]] = []
+                for tc in record.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        fn = tc.get("function") or {}
+                        tool_uses.append({
+                            "name": fn.get("name", ""),
+                            "input": fn.get("arguments", {}),
+                        })
+
+                turns.append({
+                    "uuid": turn_id,
+                    "session_id": record.get("session_id", ""),
+                    "agent": "codex",
+                    "model": record.get("model", ""),
+                    "timestamp": record.get("created_at", ""),
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cache_read_tokens": cache_read_tokens,
+                    "cache_write_tokens": 0,
+                    "tool_uses": tool_uses,
+                    "raw": record,
+                })
+
+        return turns

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1,0 +1,165 @@
+"""Fixture-driven tests for the Codex CLI adapter — issue #5."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from t01_burnmap.adapters.codex import CodexAdapter
+
+FIXTURES = Path(__file__).parent / "fixtures" / "codex"
+
+
+@pytest.fixture
+def adapter() -> CodexAdapter:
+    return CodexAdapter()
+
+
+# ---------------------------------------------------------------------------
+# is_supported_file
+# ---------------------------------------------------------------------------
+
+class TestIsSupportedFile:
+    def test_jsonl_accepted(self, adapter):
+        assert adapter.is_supported_file(Path("session.jsonl"))
+
+    def test_json_rejected(self, adapter):
+        assert not adapter.is_supported_file(Path("session.json"))
+
+    def test_txt_rejected(self, adapter):
+        assert not adapter.is_supported_file(Path("log.txt"))
+
+
+# ---------------------------------------------------------------------------
+# v1 fixture — flat token fields
+# ---------------------------------------------------------------------------
+
+class TestV1Fixture:
+    @pytest.fixture
+    def turns(self, adapter, tmp_path):
+        data = json.loads((FIXTURES / "v1_turn.json").read_text())
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(json.dumps(data) + "\n")
+        return adapter.parse_file(jsonl)
+
+    def test_returns_one_turn(self, turns):
+        assert len(turns) == 1
+
+    def test_uuid(self, turns):
+        assert turns[0]["uuid"] == "codex-turn-v1-001"
+
+    def test_session_id(self, turns):
+        assert turns[0]["session_id"] == "codex-session-aaa"
+
+    def test_agent(self, turns):
+        assert turns[0]["agent"] == "codex"
+
+    def test_model(self, turns):
+        assert turns[0]["model"] == "gpt-4o"
+
+    def test_input_tokens(self, turns):
+        assert turns[0]["input_tokens"] == 600
+
+    def test_output_tokens(self, turns):
+        assert turns[0]["output_tokens"] == 150
+
+    def test_cache_read_tokens_zero(self, turns):
+        assert turns[0]["cache_read_tokens"] == 0
+
+    def test_no_tool_uses(self, turns):
+        assert turns[0]["tool_uses"] == []
+
+
+# ---------------------------------------------------------------------------
+# v2 fixture — nested usage, cached_tokens
+# ---------------------------------------------------------------------------
+
+class TestV2Fixture:
+    @pytest.fixture
+    def turns(self, adapter, tmp_path):
+        data = json.loads((FIXTURES / "v2_turn.json").read_text())
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(json.dumps(data) + "\n")
+        return adapter.parse_file(jsonl)
+
+    def test_returns_one_turn(self, turns):
+        assert len(turns) == 1
+
+    def test_uuid(self, turns):
+        assert turns[0]["uuid"] == "codex-turn-v2-001"
+
+    def test_session_id(self, turns):
+        assert turns[0]["session_id"] == "codex-session-bbb"
+
+    def test_model(self, turns):
+        assert turns[0]["model"] == "gpt-4o-mini"
+
+    def test_input_tokens(self, turns):
+        assert turns[0]["input_tokens"] == 900
+
+    def test_output_tokens(self, turns):
+        assert turns[0]["output_tokens"] == 210
+
+    def test_cache_read_tokens(self, turns):
+        assert turns[0]["cache_read_tokens"] == 400
+
+
+# ---------------------------------------------------------------------------
+# Dedup by id (turn_id)
+# ---------------------------------------------------------------------------
+
+class TestDedup:
+    def test_dedup_by_id(self, adapter, tmp_path):
+        data = json.loads((FIXTURES / "v1_turn.json").read_text())
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(json.dumps(data) + "\n" + json.dumps(data) + "\n")
+        turns = adapter.parse_file(jsonl)
+        assert len(turns) == 1
+
+    def test_different_ids_both_kept(self, adapter, tmp_path):
+        d1 = json.loads((FIXTURES / "v1_turn.json").read_text())
+        d2 = json.loads((FIXTURES / "v2_turn.json").read_text())
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(json.dumps(d1) + "\n" + json.dumps(d2) + "\n")
+        turns = adapter.parse_file(jsonl)
+        assert len(turns) == 2
+
+
+# ---------------------------------------------------------------------------
+# Filtering / robustness
+# ---------------------------------------------------------------------------
+
+class TestFiltering:
+    def test_skips_records_without_id(self, adapter, tmp_path):
+        record = {"session_id": "s1", "model": "gpt-4o", "prompt_tokens": 100, "completion_tokens": 50}
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(json.dumps(record) + "\n")
+        assert adapter.parse_file(jsonl) == []
+
+    def test_skips_malformed_json(self, adapter, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text("not json\n{bad\n")
+        assert adapter.parse_file(jsonl) == []
+
+    def test_skips_empty_lines(self, adapter, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text("\n\n\n")
+        assert adapter.parse_file(jsonl) == []
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn file
+# ---------------------------------------------------------------------------
+
+class TestMultiTurn:
+    def test_multi_turn_file(self, adapter, tmp_path):
+        d1 = json.loads((FIXTURES / "v1_turn.json").read_text())
+        d2 = json.loads((FIXTURES / "v2_turn.json").read_text())
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(json.dumps(d1) + "\n" + json.dumps(d2) + "\n")
+        turns = adapter.parse_file(jsonl)
+        assert len(turns) == 2
+        uuids = {t["uuid"] for t in turns}
+        assert "codex-turn-v1-001" in uuids
+        assert "codex-turn-v2-001" in uuids


### PR DESCRIPTION
Closes #5

## What
Adds `CodexAdapter` that parses `~/.codex/sessions/*.jsonl` files.

## Changes
- `t01_burnmap/adapters/codex.py` — new adapter (dedup by `id`, v1 flat + v2 nested usage)
- `t01_burnmap/adapters/__init__.py` — exports `CodexAdapter`
- `tests/test_codex_adapter.py` — 25 fixture-driven tests (all passing)