### PR TITLE
feat: Aider adapter — parse markdown chat history

### DIFF
--- a/t01_burnmap/adapters/aider.py
+++ b/t01_burnmap/adapters/aider.py
@@ -1,0 +1,101 @@
+"""Aider adapter — parses ~/.aider.chat.history.md markdown chat logs."""
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .base import BaseAdapter
+
+# Matches: "# aider chat started at 2024-01-15 10:30:00"
+_SESSION_RE = re.compile(r"^# aider chat started at (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", re.MULTILINE)
+
+# Matches token lines in two variants:
+#   > Tokens: 1200 sent, 340 received, cost $0.0150 message, ...
+#   > Tokens: 800 sent, 210 received. Cost: $0.0085 message, ...
+_TOKENS_RE = re.compile(
+    r"Tokens:\s+(\d[\d,]*)\s+sent,\s+(\d[\d,]*)\s+received[.,]?\s+[Cc]ost[: \$]+\$([\d.]+)\s+message",
+)
+
+
+def _parse_timestamp(dt_str: str) -> int:
+    """Return milliseconds since epoch for a 'YYYY-MM-DD HH:MM:SS' string."""
+    dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _make_uuid(session_id: str, turn_index: int) -> str:
+    raw = f"{session_id}:{turn_index}"
+    return "aider-" + hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+
+class AiderAdapter(BaseAdapter):
+    """Parses Aider markdown chat history files.
+
+    Aider logs are a single append-only markdown file. Sessions are delimited
+    by '# aider chat started at ...' headings. Each user turn (#### heading)
+    followed by a '> Tokens: ...' line constitutes one turn record.
+    """
+
+    def default_paths(self) -> list[Path]:
+        return [Path.home() / ".aider.chat.history.md"]
+
+    def is_supported_file(self, path: Path) -> bool:
+        return path.name.endswith(".chat.history.md")
+
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        """Parse an Aider markdown history file and return raw turn records."""
+        text = path.read_text(encoding="utf-8", errors="replace")
+        turns: list[dict[str, Any]] = []
+
+        # Split into session blocks by session header
+        session_matches = list(_SESSION_RE.finditer(text))
+        if not session_matches:
+            return turns
+
+        for i, m in enumerate(session_matches):
+            session_dt_str = m.group(1)
+            session_ts = _parse_timestamp(session_dt_str)
+            # Unique session id from timestamp
+            session_id = "aider-" + session_dt_str.replace(" ", "T").replace(":", "-")
+
+            block_start = m.end()
+            block_end = session_matches[i + 1].start() if i + 1 < len(session_matches) else len(text)
+            block = text[block_start:block_end]
+
+            # Find all token lines in this session block
+            for turn_index, tok_match in enumerate(_TOKENS_RE.finditer(block)):
+                sent = int(tok_match.group(1).replace(",", ""))
+                received = int(tok_match.group(2).replace(",", ""))
+                cost = float(tok_match.group(3))
+
+                # Find user prompt: last #### heading before this token line
+                block_before = block[: tok_match.start()]
+                prompt_match = list(re.finditer(r"^####\s+(.+)$", block_before, re.MULTILINE))
+                prompt_text = prompt_match[-1].group(1).strip() if prompt_match else ""
+
+                uid = _make_uuid(session_id, turn_index)
+                turns.append({
+                    "uuid": uid,
+                    "session_id": session_id,
+                    "agent": "aider",
+                    "model": "",          # not present in history file
+                    "timestamp": session_dt_str,
+                    "timestamp_ms": session_ts,
+                    "input_tokens": sent,
+                    "output_tokens": received,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "cost_usd": cost,
+                    "prompt_text": prompt_text,
+                    "tool_uses": [],
+                    "raw": {
+                        "session_id": session_id,
+                        "turn_index": turn_index,
+                        "raw_tokens_line": tok_match.group(0),
+                    },
+                })
+
+        return turns

--- a/tests/fixtures/aider/multi_session.md
+++ b/tests/fixtures/aider/multi_session.md
@@ -1,0 +1,22 @@
+
+# aider chat started at 2024-01-15 10:30:00
+
+#### First session question
+
+> Tokens: 500 sent, 100 received, cost $0.0060 message, $0.0060 session.
+
+First session answer.
+
+# aider chat started at 2024-01-15 14:00:00
+
+#### Second session question
+
+> Tokens: 600 sent, 120 received. Cost: $0.0072 message, $0.0072 session.
+
+Second session answer.
+
+#### Second turn in second session
+
+> Tokens: 700 sent, 150 received, cost $0.0085 message, $0.0157 session.
+
+Second turn answer.

--- a/tests/fixtures/aider/single_session.md
+++ b/tests/fixtures/aider/single_session.md
@@ -1,0 +1,20 @@
+
+# aider chat started at 2024-01-15 10:30:00
+
+> /add burnmap/app.py
+
+#### Fix the import error in app.py
+
+> Tokens: 1200 sent, 340 received, cost $0.0150 message, $0.0150 session.
+
+I'll fix the import error in `burnmap/app.py`.
+
+```python
+from fastapi import FastAPI
+```
+
+#### Add a health endpoint
+
+> Tokens: 800 sent, 210 received. Cost: $0.0085 message, $0.0235 session.
+
+Here's the health endpoint implementation.

--- a/tests/test_aider_adapter.py
+++ b/tests/test_aider_adapter.py
@@ -1,0 +1,107 @@
+"""Fixture-driven tests for the Aider adapter — issue #7."""
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+from t01_burnmap.adapters.aider import AiderAdapter
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "aider"
+
+
+@pytest.fixture
+def adapter() -> AiderAdapter:
+    return AiderAdapter()
+
+
+class TestDefaultPaths:
+    def test_returns_aider_history(self, adapter):
+        paths = adapter.default_paths()
+        assert len(paths) == 1
+        assert paths[0].name == ".aider.chat.history.md"
+
+
+class TestIsSupportedFile:
+    def test_accepts_aider_history(self, adapter):
+        assert adapter.is_supported_file(Path(".aider.chat.history.md"))
+
+    def test_rejects_jsonl(self, adapter):
+        assert not adapter.is_supported_file(Path("session.jsonl"))
+
+    def test_rejects_plain_md(self, adapter):
+        assert not adapter.is_supported_file(Path("notes.md"))
+
+
+class TestSingleSession:
+    @pytest.fixture
+    def turns(self, adapter):
+        return adapter.parse_file(FIXTURES / "single_session.md")
+
+    def test_returns_two_turns(self, turns):
+        assert len(turns) == 2
+
+    def test_agent(self, turns):
+        assert turns[0]["agent"] == "aider"
+
+    def test_session_id(self, turns):
+        assert turns[0]["session_id"] == "aider-2024-01-15T10-30-00"
+
+    def test_both_turns_same_session(self, turns):
+        assert turns[0]["session_id"] == turns[1]["session_id"]
+
+    def test_input_tokens_first_turn(self, turns):
+        assert turns[0]["input_tokens"] == 1200
+
+    def test_output_tokens_first_turn(self, turns):
+        assert turns[0]["output_tokens"] == 340
+
+    def test_cost_usd_first_turn(self, turns):
+        assert turns[0]["cost_usd"] == pytest.approx(0.0150)
+
+    def test_prompt_text_extracted(self, turns):
+        assert turns[0]["prompt_text"] == "Fix the import error in app.py"
+
+    def test_second_turn_input_tokens(self, turns):
+        assert turns[1]["input_tokens"] == 800
+
+    def test_uuid_unique(self, turns):
+        assert turns[0]["uuid"] != turns[1]["uuid"]
+
+    def test_uuid_prefix(self, turns):
+        assert turns[0]["uuid"].startswith("aider-")
+
+    def test_timestamp_ms_positive(self, turns):
+        assert turns[0]["timestamp_ms"] > 0
+
+
+class TestMultiSession:
+    @pytest.fixture
+    def turns(self, adapter):
+        return adapter.parse_file(FIXTURES / "multi_session.md")
+
+    def test_returns_three_turns(self, turns):
+        assert len(turns) == 3
+
+    def test_two_distinct_sessions(self, turns):
+        session_ids = {t["session_id"] for t in turns}
+        assert len(session_ids) == 2
+
+    def test_first_session_one_turn(self, turns):
+        first_sid = "aider-2024-01-15T10-30-00"
+        assert sum(1 for t in turns if t["session_id"] == first_sid) == 1
+
+    def test_second_session_two_turns(self, turns):
+        second_sid = "aider-2024-01-15T14-00-00"
+        assert sum(1 for t in turns if t["session_id"] == second_sid) == 2
+
+
+class TestEmptyFile:
+    def test_empty_returns_empty_list(self, adapter, tmp_path):
+        f = tmp_path / "empty.chat.history.md"
+        f.write_text("")
+        assert adapter.parse_file(f) == []
+
+    def test_no_token_lines_returns_empty(self, adapter, tmp_path):
+        f = tmp_path / "notokens.chat.history.md"
+        f.write_text("# aider chat started at 2024-01-01 00:00:00\n\n#### hi\n\nsome response\n")
+        assert adapter.parse_file(f) == []


### PR DESCRIPTION
Closes #7

## What
Implements adapter for `~/.aider.chat.history.md`. Parses markdown chat log into sessions and turns.

## Acceptance Criteria
- [x] Parses Aider markdown history format
- [x] Extracts sessions, turns
- [x] Fixture-driven tests

## Changes
- New adapter: `t01_burnmap/adapters/aider.py` (101 lines)
- Tests: `tests/test_aider_adapter.py` (22 test cases, all passing)
- Fixtures: single_session.md and multi_session.md for test coverage

All 348 tests pass.