### PR TITLE
feat: Cline adapter — parse task JSON files

### DIFF
--- a/t01_burnmap/adapters/__init__.py
+++ b/t01_burnmap/adapters/__init__.py
@@ -1,4 +1,5 @@
 from .base import BaseAdapter
+from .cline import ClineAdapter
 from .registry import AdapterRegistry
 
-__all__ = ["BaseAdapter", "AdapterRegistry"]
+__all__ = ["BaseAdapter", "AdapterRegistry", "ClineAdapter"]

--- a/t01_burnmap/adapters/cline.py
+++ b/t01_burnmap/adapters/cline.py
@@ -1,0 +1,65 @@
+"""Cline adapter — parses tasks/*.json task metadata files."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .base import BaseAdapter
+
+_CLINE_GLOB = "tasks/*/task_metadata.json"
+
+
+class ClineAdapter(BaseAdapter):
+    """Parses Cline task metadata JSON files.
+
+    Each ``task_metadata.json`` represents one session/task.
+    Token usage is stored at the task level (tokensIn/tokensOut/cacheWrites/cacheReads).
+    """
+
+    def default_paths(self) -> list[Path]:
+        base = (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Code"
+            / "User"
+            / "globalStorage"
+            / "saoudrizwan.claude-dev"
+        )
+        return list(base.glob(_CLINE_GLOB))
+
+    def is_supported_file(self, path: Path) -> bool:
+        return path.name == "task_metadata.json"
+
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        """Return a single normalised turn record from a Cline task_metadata.json."""
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return []
+
+        task_id = record.get("id", path.parent.name)
+        ts_raw = record.get("ts")
+        timestamp = (
+            datetime.fromtimestamp(ts_raw / 1000, tz=timezone.utc).isoformat()
+            if isinstance(ts_raw, (int, float))
+            else ""
+        )
+
+        return [
+            {
+                "uuid": task_id,
+                "session_id": task_id,
+                "agent": "cline",
+                "model": record.get("modelId", ""),
+                "timestamp": timestamp,
+                "input_tokens": record.get("tokensIn", 0),
+                "output_tokens": record.get("tokensOut", 0),
+                "cache_read_tokens": record.get("cacheReads", 0),
+                "cache_write_tokens": record.get("cacheWrites", 0),
+                "tool_uses": [],
+                "raw": record,
+            }
+        ]

--- a/tests/fixtures/cline/task_metadata_v1.json
+++ b/tests/fixtures/cline/task_metadata_v1.json
@@ -1,0 +1,12 @@
+{
+  "id": "cline-task-001",
+  "ulid": "01JNZXABCDEF",
+  "ts": 1704067200000,
+  "task": "Implement login page",
+  "tokensIn": 2500,
+  "tokensOut": 480,
+  "cacheWrites": 200,
+  "cacheReads": 100,
+  "totalCost": 0.045,
+  "modelId": "claude-3-5-sonnet-20241022"
+}

--- a/tests/fixtures/cline/task_metadata_v2.json
+++ b/tests/fixtures/cline/task_metadata_v2.json
@@ -1,0 +1,9 @@
+{
+  "id": "cline-task-002",
+  "ts": 1706745600000,
+  "task": "Fix authentication bug",
+  "tokensIn": 900,
+  "tokensOut": 210,
+  "totalCost": 0.012,
+  "modelId": "claude-3-haiku-20240307"
+}

--- a/tests/test_cline_adapter.py
+++ b/tests/test_cline_adapter.py
@@ -1,0 +1,107 @@
+"""Fixture-driven tests for the Cline adapter — issue #6."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from t01_burnmap.adapters.cline import ClineAdapter
+
+FIXTURES = Path(__file__).parent / "fixtures" / "cline"
+
+
+@pytest.fixture
+def adapter() -> ClineAdapter:
+    return ClineAdapter()
+
+
+class TestIsSupportedFile:
+    def test_task_metadata_accepted(self, adapter):
+        assert adapter.is_supported_file(Path("task_metadata.json"))
+
+    def test_api_conversation_rejected(self, adapter):
+        assert not adapter.is_supported_file(Path("api_conversation_history.json"))
+
+    def test_jsonl_rejected(self, adapter):
+        assert not adapter.is_supported_file(Path("session.jsonl"))
+
+
+class TestV1Fixture:
+    @pytest.fixture
+    def turns(self, adapter):
+        return adapter.parse_file(FIXTURES / "task_metadata_v1.json")
+
+    def test_returns_one_turn(self, turns):
+        assert len(turns) == 1
+
+    def test_session_id(self, turns):
+        assert turns[0]["session_id"] == "cline-task-001"
+
+    def test_uuid(self, turns):
+        assert turns[0]["uuid"] == "cline-task-001"
+
+    def test_agent(self, turns):
+        assert turns[0]["agent"] == "cline"
+
+    def test_model(self, turns):
+        assert turns[0]["model"] == "claude-3-5-sonnet-20241022"
+
+    def test_input_tokens(self, turns):
+        assert turns[0]["input_tokens"] == 2500
+
+    def test_output_tokens(self, turns):
+        assert turns[0]["output_tokens"] == 480
+
+    def test_cache_write_tokens(self, turns):
+        assert turns[0]["cache_write_tokens"] == 200
+
+    def test_cache_read_tokens(self, turns):
+        assert turns[0]["cache_read_tokens"] == 100
+
+    def test_timestamp_iso(self, turns):
+        assert turns[0]["timestamp"].startswith("2024-01-01")
+
+    def test_tool_uses_empty(self, turns):
+        assert turns[0]["tool_uses"] == []
+
+    def test_raw_preserved(self, turns):
+        assert turns[0]["raw"]["task"] == "Implement login page"
+
+
+class TestV2Fixture:
+    """v2: no cacheWrites/cacheReads — optional fields default to 0."""
+
+    @pytest.fixture
+    def turns(self, adapter):
+        return adapter.parse_file(FIXTURES / "task_metadata_v2.json")
+
+    def test_returns_one_turn(self, turns):
+        assert len(turns) == 1
+
+    def test_cache_tokens_default_zero(self, turns):
+        assert turns[0]["cache_write_tokens"] == 0
+        assert turns[0]["cache_read_tokens"] == 0
+
+    def test_model(self, turns):
+        assert turns[0]["model"] == "claude-3-haiku-20240307"
+
+
+class TestMalformedFile:
+    def test_invalid_json_returns_empty(self, adapter, tmp_path):
+        bad = tmp_path / "task_metadata.json"
+        bad.write_text("{not valid json", encoding="utf-8")
+        assert adapter.parse_file(bad) == []
+
+    def test_missing_file_returns_empty(self, adapter, tmp_path):
+        assert adapter.parse_file(tmp_path / "task_metadata.json") == []
+
+
+class TestTaskIdFallback:
+    def test_uses_parent_dir_name_when_no_id(self, adapter, tmp_path):
+        task_dir = tmp_path / "fallback-task-xyz"
+        task_dir.mkdir()
+        meta = task_dir / "task_metadata.json"
+        meta.write_text(json.dumps({"ts": 0, "tokensIn": 10, "tokensOut": 5}), encoding="utf-8")
+        turns = adapter.parse_file(meta)
+        assert turns[0]["session_id"] == "fallback-task-xyz"


### PR DESCRIPTION
Closes #6

## Summary
Implements the Cline adapter to parse task metadata JSON files.

- Parses Cline `tasks/*/task_metadata.json` format
- Extracts session ID, token counts (input/output/cache), model, timestamp
- Handles optional fields gracefully (cache_writes, cache_reads default to 0)
- Fallback to parent directory name for task ID if missing
- 21 fixture-driven tests covering v1/v2 formats, malformed files, edge cases
- All 347 tests pass

## Acceptance Criteria
- [x] Parses Cline task JSON format
- [x] Extracts sessions, turns
- [x] Fixture-driven tests