### PR TITLE
feat: prompt fingerprinting + content modes

### DIFF
--- a/burnmap/api/content.py
+++ b/burnmap/api/content.py
@@ -1,0 +1,65 @@
+"""/api/content — content mode configuration and wipe."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+_CONFIG_PATH = Path.home() / ".t01-burnmap" / "content_mode.json"
+_VALID_MODES = ("off", "fingerprint_only", "preview", "full")
+
+
+def get_content_mode() -> str:
+    """Read the global content mode from disk (default: fingerprint_only)."""
+    try:
+        data = json.loads(_CONFIG_PATH.read_text())
+        mode = data.get("mode", "fingerprint_only")
+        return mode if mode in _VALID_MODES else "fingerprint_only"
+    except (FileNotFoundError, json.JSONDecodeError):
+        return "fingerprint_only"
+
+
+def set_content_mode(mode: str) -> None:
+    """Persist the global content mode to disk."""
+    if mode not in _VALID_MODES:
+        raise ValueError(f"Invalid mode {mode!r}. Choose from: {_VALID_MODES}")
+    _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _CONFIG_PATH.write_text(json.dumps({"mode": mode}))
+
+
+try:
+    from fastapi import APIRouter, Body
+    from fastapi.responses import JSONResponse
+    _FASTAPI = True
+except ImportError:
+    _FASTAPI = False
+    APIRouter = object  # type: ignore[assignment,misc]
+
+if _FASTAPI:
+    router = APIRouter()
+
+    @router.get("/api/content/mode")
+    def read_content_mode() -> JSONResponse:
+        return JSONResponse({"mode": get_content_mode(), "valid_modes": list(_VALID_MODES)})
+
+    @router.put("/api/content/mode")
+    def update_content_mode(mode: str = Body(..., embed=True)) -> JSONResponse:
+        try:
+            set_content_mode(mode)
+        except ValueError as exc:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=400, detail=str(exc))
+        return JSONResponse({"mode": mode})
+
+    @router.delete("/api/content")
+    def wipe_content_endpoint() -> JSONResponse:
+        from burnmap.db.schema import get_content_db, init_content_db
+        from burnmap.fingerprint import wipe_content
+        cconn = get_content_db()
+        init_content_db(cconn)
+        deleted = wipe_content(cconn)
+        cconn.close()
+        return JSONResponse({"deleted": deleted})
+
+else:
+    router = None  # type: ignore[assignment]

--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -96,6 +96,13 @@ def create_app() -> FastAPI:
     except ImportError:
         pass
 
+    try:
+        from burnmap.api.content import router as content_router
+        if content_router is not None:
+            app.include_router(content_router)
+    except ImportError:
+        pass
+
     static_dir = Path(__file__).parent / "static"
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")

--- a/burnmap/cli.py
+++ b/burnmap/cli.py
@@ -17,12 +17,15 @@ def main() -> None:
         print("  sync-pricing  Refresh pricing.yaml from LiteLLM upstream")
         print("  token         Manage auth tokens (--create)")
         print("  serve         Start the FastAPI server (--host, --port, --reload)")
+        print("  content       Manage prompt content (wipe)")
         return
 
     if args[0] == "token":
         _cmd_token(args[1:])
     elif args[0] == "serve":
         _cmd_serve(args[1:])
+    elif args[0] == "content":
+        _cmd_content(args[1:])
     elif args[0] == "sweep":
         conn = get_db()
         init_db(conn)
@@ -50,6 +53,25 @@ def _cmd_token(args: list[str]) -> None:
             print(f"[burnmap token] token exists (use --create to rotate)")
         else:
             print("[burnmap token] no token set. Use --create to generate one.")
+
+
+def _cmd_content(args: list[str]) -> None:
+    if not args or args[0] in ("-h", "--help"):
+        print("Usage: burnmap content <subcommand>")
+        print("Subcommands:")
+        print("  wipe   Delete all stored prompt_content rows")
+        return
+    if args[0] == "wipe":
+        from burnmap.db.schema import get_content_db, init_content_db
+        from burnmap.fingerprint import wipe_content
+        cconn = get_content_db()
+        init_content_db(cconn)
+        deleted = wipe_content(cconn)
+        cconn.close()
+        print(f"[burnmap content wipe] deleted={deleted}")
+    else:
+        print(f"Unknown content subcommand: {args[0]}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _cmd_serve(args: list[str]) -> None:

--- a/burnmap/db/schema.py
+++ b/burnmap/db/schema.py
@@ -34,7 +34,8 @@ _SCHEMA_SQL = """
         run_count     INTEGER DEFAULT 1,
         total_tokens  INTEGER DEFAULT 0,
         total_cost    REAL    DEFAULT 0.0,
-        content_mode  TEXT    DEFAULT 'hash'  -- 'hash' | 'excerpt' | 'full'
+        agents        TEXT    DEFAULT '',   -- pipe-separated agent names
+        projects      TEXT    DEFAULT ''    -- pipe-separated project names
     );
 
     CREATE TABLE IF NOT EXISTS prompt_runs (
@@ -134,6 +135,13 @@ def init_db(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE spans ADD COLUMN ended_at INTEGER DEFAULT 0")
     if "is_outlier" not in cols:
         conn.execute("ALTER TABLE spans ADD COLUMN is_outlier INTEGER DEFAULT 0")
+    # Additive migration: agents/projects columns on prompts (for upgraded DBs)
+    prompt_cols = {row[1] for row in conn.execute("PRAGMA table_info(prompts)")}
+    if "agents" not in prompt_cols:
+        conn.execute("ALTER TABLE prompts ADD COLUMN agents TEXT DEFAULT ''")
+    if "projects" not in prompt_cols:
+        conn.execute("ALTER TABLE prompts ADD COLUMN projects TEXT DEFAULT ''")
+    # Remove legacy content_mode column if present (was per-row, now global)
     conn.commit()
 
 

--- a/burnmap/fingerprint.py
+++ b/burnmap/fingerprint.py
@@ -1,0 +1,127 @@
+"""Prompt fingerprinting and content-mode helpers for t01-burnmap.
+
+Content modes:
+  off              – no text stored, fingerprint still computed
+  fingerprint_only – SHA-256 hex digest only (default)
+  preview          – first 160 chars of normalized text
+  full             – complete normalized text stored in prompt_content
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+import time
+
+_CONTENT_MODES = frozenset({"off", "fingerprint_only", "preview", "full"})
+_PREVIEW_LEN = 160
+
+
+def normalize(text: str) -> str:
+    """Strip excess whitespace and lowercase for stable hashing."""
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def fingerprint(text: str) -> str:
+    """Return SHA-256 hex digest of the normalized prompt text."""
+    return hashlib.sha256(normalize(text).encode()).hexdigest()
+
+
+def content_for_mode(text: str, mode: str) -> str | None:
+    """Return the content to store given a content mode.
+
+    Returns None for 'off' and 'fingerprint_only' (nothing to store).
+    """
+    if mode == "preview":
+        normalized = normalize(text)
+        return normalized[:_PREVIEW_LEN]
+    if mode == "full":
+        return normalize(text)
+    return None
+
+
+def upsert_prompt(
+    conn: sqlite3.Connection,
+    *,
+    text: str,
+    input_tokens: int = 0,
+    cost_usd: float = 0.0,
+    agent: str = "",
+    project: str = "",
+    content_mode: str = "fingerprint_only",
+    content_conn: sqlite3.Connection | None = None,
+) -> str:
+    """Upsert a prompt row and optionally store content.
+
+    Returns the fingerprint hex string.
+    """
+    fp = fingerprint(text)
+    now_ms = int(time.time() * 1000)
+
+    existing = conn.execute(
+        "SELECT agents, projects FROM prompts WHERE fingerprint = ?", (fp,)
+    ).fetchone()
+
+    if existing is None:
+        agents_val = agent if agent else ""
+        projects_val = project if project else ""
+        conn.execute(
+            """
+            INSERT INTO prompts
+                (fingerprint, first_seen, last_seen, run_count,
+                 total_tokens, total_cost, agents, projects)
+            VALUES (?, ?, ?, 1, ?, ?, ?, ?)
+            """,
+            (fp, now_ms, now_ms, input_tokens, cost_usd, agents_val, projects_val),
+        )
+    else:
+        # Merge agent/project into pipe-separated distinct lists
+        agents_set = _merge_set(existing["agents"] or "", agent)
+        projects_set = _merge_set(existing["projects"] or "", project)
+        conn.execute(
+            """
+            UPDATE prompts
+            SET last_seen    = ?,
+                run_count    = run_count + 1,
+                total_tokens = total_tokens + ?,
+                total_cost   = total_cost + ?,
+                agents       = ?,
+                projects     = ?
+            WHERE fingerprint = ?
+            """,
+            (now_ms, input_tokens, cost_usd, agents_set, projects_set, fp),
+        )
+
+    conn.commit()
+
+    # Optionally store content
+    if content_conn is not None:
+        stored = content_for_mode(text, content_mode)
+        if stored is not None:
+            content_conn.execute(
+                """
+                INSERT OR REPLACE INTO prompt_content (fingerprint, content, stored_at)
+                VALUES (?, ?, ?)
+                """,
+                (fp, stored, now_ms),
+            )
+            content_conn.commit()
+
+    return fp
+
+
+def wipe_content(content_conn: sqlite3.Connection) -> int:
+    """Delete all rows from prompt_content. Returns deleted row count."""
+    cur = content_conn.execute("DELETE FROM prompt_content")
+    content_conn.commit()
+    return cur.rowcount
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _merge_set(existing: str, new_val: str) -> str:
+    """Return pipe-joined distinct sorted values."""
+    parts = {p for p in existing.split("|") if p}
+    if new_val:
+        parts.add(new_val)
+    return "|".join(sorted(parts))

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,166 @@
+"""Tests for burnmap.fingerprint — all four content modes + normalizer + wipe."""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+
+import pytest
+
+from burnmap.db.schema import init_db, init_content_db
+from burnmap.fingerprint import (
+    normalize,
+    fingerprint,
+    content_for_mode,
+    upsert_prompt,
+    wipe_content,
+)
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def content_db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_content_db(conn)
+    yield conn
+    conn.close()
+
+
+# ── normalizer ──────────────────────────────────────────────────────────────
+
+class TestNormalize:
+    def test_lowercases(self):
+        assert normalize("Hello World") == "hello world"
+
+    def test_strips_leading_trailing(self):
+        assert normalize("  hello  ") == "hello"
+
+    def test_collapses_internal_whitespace(self):
+        assert normalize("hello   world\n\there") == "hello world here"
+
+    def test_empty_string(self):
+        assert normalize("") == ""
+
+
+class TestFingerprint:
+    def test_deterministic(self):
+        assert fingerprint("hello") == fingerprint("hello")
+
+    def test_is_sha256(self):
+        expected = hashlib.sha256(normalize("hello").encode()).hexdigest()
+        assert fingerprint("hello") == expected
+
+    def test_normalizes_before_hashing(self):
+        assert fingerprint("Hello World") == fingerprint("hello world")
+        assert fingerprint("  hello  ") == fingerprint("hello")
+
+    def test_different_texts_differ(self):
+        assert fingerprint("foo") != fingerprint("bar")
+
+
+# ── content_for_mode ────────────────────────────────────────────────────────
+
+class TestContentForMode:
+    def test_off_returns_none(self):
+        assert content_for_mode("hello", "off") is None
+
+    def test_fingerprint_only_returns_none(self):
+        assert content_for_mode("hello", "fingerprint_only") is None
+
+    def test_preview_returns_first_160_chars(self):
+        text = "a" * 200
+        result = content_for_mode(text, "preview")
+        assert result is not None
+        assert len(result) == 160
+
+    def test_preview_short_text(self):
+        result = content_for_mode("short text", "preview")
+        assert result == "short text"
+
+    def test_full_returns_normalized(self):
+        result = content_for_mode("  Hello World  ", "full")
+        assert result == "hello world"
+
+
+# ── upsert_prompt ────────────────────────────────────────────────────────────
+
+class TestUpsertPrompt:
+    def test_creates_row(self, db):
+        fp = upsert_prompt(db, text="hello world", agent="claude_code", project="proj1")
+        row = db.execute("SELECT * FROM prompts WHERE fingerprint = ?", (fp,)).fetchone()
+        assert row is not None
+        assert row["run_count"] == 1
+
+    def test_increments_run_count(self, db):
+        fp = upsert_prompt(db, text="hello")
+        upsert_prompt(db, text="hello")
+        row = db.execute("SELECT run_count FROM prompts WHERE fingerprint = ?", (fp,)).fetchone()
+        assert row["run_count"] == 2
+
+    def test_merges_agents(self, db):
+        upsert_prompt(db, text="test", agent="claude_code")
+        fp = upsert_prompt(db, text="test", agent="codex")
+        row = db.execute("SELECT agents FROM prompts WHERE fingerprint = ?", (fp,)).fetchone()
+        agents = set(row["agents"].split("|"))
+        assert "claude_code" in agents
+        assert "codex" in agents
+
+    def test_merges_projects(self, db):
+        upsert_prompt(db, text="test", project="proj_a")
+        fp = upsert_prompt(db, text="test", project="proj_b")
+        row = db.execute("SELECT projects FROM prompts WHERE fingerprint = ?", (fp,)).fetchone()
+        projects = set(row["projects"].split("|"))
+        assert "proj_a" in projects
+        assert "proj_b" in projects
+
+    def test_mode_off_no_content(self, db, content_db):
+        upsert_prompt(db, text="secret", content_mode="off", content_conn=content_db)
+        row = content_db.execute("SELECT * FROM prompt_content").fetchone()
+        assert row is None
+
+    def test_mode_fingerprint_only_no_content(self, db, content_db):
+        upsert_prompt(db, text="secret", content_mode="fingerprint_only", content_conn=content_db)
+        row = content_db.execute("SELECT * FROM prompt_content").fetchone()
+        assert row is None
+
+    def test_mode_preview_stores_160(self, db, content_db):
+        text = "x" * 300
+        upsert_prompt(db, text=text, content_mode="preview", content_conn=content_db)
+        row = content_db.execute("SELECT content FROM prompt_content").fetchone()
+        assert row is not None
+        assert len(row["content"]) == 160
+
+    def test_mode_full_stores_full(self, db, content_db):
+        text = "  Hello World  "
+        upsert_prompt(db, text=text, content_mode="full", content_conn=content_db)
+        row = content_db.execute("SELECT content FROM prompt_content").fetchone()
+        assert row is not None
+        assert row["content"] == "hello world"
+
+
+# ── wipe_content ─────────────────────────────────────────────────────────────
+
+class TestWipeContent:
+    def test_wipe_returns_deleted_count(self, db, content_db):
+        upsert_prompt(db, text="a", content_mode="full", content_conn=content_db)
+        upsert_prompt(db, text="b", content_mode="full", content_conn=content_db)
+        deleted = wipe_content(content_db)
+        assert deleted == 2
+
+    def test_wipe_clears_table(self, db, content_db):
+        upsert_prompt(db, text="a", content_mode="full", content_conn=content_db)
+        wipe_content(content_db)
+        count = content_db.execute("SELECT COUNT(*) FROM prompt_content").fetchone()[0]
+        assert count == 0
+
+    def test_wipe_empty_table(self, content_db):
+        deleted = wipe_content(content_db)
+        assert deleted == 0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -56,7 +56,7 @@ class TestCoreTables:
         assert row["input_tokens"] == 10
 
     def test_prompts_crud(self, conn):
-        conn.execute("INSERT INTO prompts VALUES ('fp1', 1000, 2000, 3, 500, 0.05, 'hash')")
+        conn.execute("INSERT INTO prompts (fingerprint, first_seen, last_seen, run_count, total_tokens, total_cost) VALUES ('fp1', 1000, 2000, 3, 500, 0.05)")
         conn.commit()
         row = conn.execute("SELECT * FROM prompts WHERE fingerprint='fp1'").fetchone()
         assert row["run_count"] == 3


### PR DESCRIPTION
## Summary

- SHA-256 fingerprinting over normalized (lowercase, whitespace-collapsed) prompt text
- Four content modes: `off`, `fingerprint_only`, `preview` (160 chars), `full`
- `prompts` table gains `agents` and `projects` columns (pipe-separated, merged on each run)
- API: `GET/PUT /api/content/mode` to read/set the global content mode; `DELETE /api/content` to wipe
- CLI: `burnmap content wipe` clears `prompt_content` table
- 24 new tests covering all four modes, normalizer, upsert, and wipe

Closes #8