### PR TITLE
fix: align schema docs to 4 content modes

### DIFF
--- a/burnmap/db/schema.py
+++ b/burnmap/db/schema.py
@@ -97,7 +97,10 @@ _SCHEMA_SQL = """
 _CONTENT_SCHEMA_SQL = """
     CREATE TABLE IF NOT EXISTS prompt_content (
         fingerprint   TEXT PRIMARY KEY,
-        content       TEXT NOT NULL,    -- full prompt text (opt-in)
+        -- Stored when content_mode is 'preview' (truncated) or 'full' (complete text).
+        -- content_mode is global: 'off' | 'fingerprint_only' | 'preview' | 'full'
+        -- Managed by burnmap/api/content.py; 'off' and 'fingerprint_only' store nothing here.
+        content       TEXT NOT NULL,
         stored_at     INTEGER DEFAULT 0
     );
 """

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -43,8 +43,7 @@ def conn(tmp_path):
             last_seen INTEGER DEFAULT 0,
             run_count INTEGER DEFAULT 1,
             total_tokens INTEGER DEFAULT 0,
-            total_cost REAL DEFAULT 0.0,
-            content_mode TEXT DEFAULT 'hash'
+            total_cost REAL DEFAULT 0.0
         );
         CREATE TABLE prompt_runs (
             id TEXT PRIMARY KEY,
@@ -76,7 +75,7 @@ class TestQueryStorageInfo:
         sid = str(uuid.uuid4())
         conn.execute("INSERT INTO sessions(id, agent) VALUES (?, 'claude_code')", (sid,))
         conn.execute(
-            "INSERT INTO prompts(fingerprint, content_mode) VALUES ('fp1', 'preview')"
+            "INSERT INTO prompts(fingerprint) VALUES ('fp1')"
         )
         conn.commit()
         with patch("burnmap.api.settings._DEFAULT_DB", fake_db):


### PR DESCRIPTION
Closes #68

Updates schema documentation and test fixtures to reflect the actual 4 content modes ('off', 'fingerprint_only', 'preview', 'full') already implemented in burnmap/api/content.py. Schema comments previously referenced stale 3-mode names.

- Updates prompt_content table comment to document all 4 modes
- Removes stale content_mode column from test fixture
- 418 tests pass