### PR TITLE
fix: /api/settings/providers crashes with 500 on missing sessions table

### DIFF
--- a/burnmap/api/settings.py
+++ b/burnmap/api/settings.py
@@ -73,11 +73,14 @@ def query_providers(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     result = []
     for adapter in adapters:
         agent = adapter["agent"]
-        row = conn.execute(
-            "SELECT COUNT(DISTINCT id) AS sessions FROM sessions WHERE agent = ?",
-            (agent,),
-        ).fetchone()
-        sessions = row["sessions"] if row else 0
+        try:
+            row = conn.execute(
+                "SELECT COUNT(DISTINCT id) AS sessions FROM sessions WHERE agent = ?",
+                (agent,),
+            ).fetchone()
+            sessions = row["sessions"] if row else 0
+        except sqlite3.OperationalError:
+            sessions = 0
         result.append({
             "agent": agent,
             "found": adapter["found"],


### PR DESCRIPTION
Closes #76

Wraps the sessions query in query_providers() with try/except sqlite3.OperationalError, defaulting to 0 sessions — same pattern used in query_storage_info().