### PR TITLE
fix: Settings page stuck on Loading when any API call fails

### DIFF
--- a/burnmap/templates/pages/settings.html
+++ b/burnmap/templates/pages/settings.html
@@ -199,15 +199,25 @@ function settingsPage() {
 
     async load() {
       this.loading = true;
-      const [stor, prov, price] = await Promise.all([
-        fetch('/api/settings/storage').then(r => r.json()),
-        fetch('/api/settings/providers').then(r => r.json()),
-        fetch('/api/settings/pricing').then(r => r.json()),
-      ]);
-      this.storage = stor;
-      this.providers = prov.providers || [];
-      this.pricing = price;
-      this.loading = false;
+      const safeJson = async (url) => {
+        try {
+          const r = await fetch(url);
+          if (!r.ok) return null;
+          return await r.json();
+        } catch { return null; }
+      };
+      try {
+        const [stor, prov, price] = await Promise.all([
+          safeJson('/api/settings/storage'),
+          safeJson('/api/settings/providers'),
+          safeJson('/api/settings/pricing'),
+        ]);
+        this.storage = stor;
+        this.providers = (prov && prov.providers) || [];
+        this.pricing = price;
+      } finally {
+        this.loading = false;
+      }
     },
 
     storageRows() {


### PR DESCRIPTION
Closes #77

## Summary
Add try/catch around Promise.all and check r.ok before .json() — loading=false always set in finally block. API failures now render empty state instead of stuck Loading spinner.

## Acceptance criteria
- [x] Settings page does not hang on API failure
- [x] loading set to false even if all endpoints fail
- [x] Graceful fallback to empty state (providers=[], storage=null, pricing=null)