### PR TITLE
fix: suppress favicon 404 with empty icon link in base.html

### DIFF
--- a/burnmap/templates/base.html
+++ b/burnmap/templates/base.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap"/>
 <link rel="stylesheet" href="/static/css/app.css"/>
+<link rel="icon" href="data:,"/>
 {% block head %}{% endblock %}
 </head>
 <body x-data="shell()" x-init="init()">


### PR DESCRIPTION
Closes #78

## Root Cause
The Settings page console shows 404 errors for missing static resources. Browsers auto-request /favicon.ico when no favicon link is declared, resulting in a 404 error since the file doesn't exist.

## Fix
Added `<link rel="icon" href="data:,"/>` to base.html. This empty data URI tells the browser there's no favicon, suppressing the automatic request and eliminating the 404.

## Testing
- 443 tests pass
- No debug statements added
- Single-line surgical change