### PR TITLE
docs: update PRD to specify three content modes

### DIFF
--- a/docs-t01-burnmap/01-prd/05-requirements.md
+++ b/docs-t01-burnmap/01-prd/05-requirements.md
@@ -18,7 +18,7 @@
 | **Prompts** | Detail: runs list, histogram, outlier flags | P0 |
 | **Tasks** | Slash commands, skills, subagent calls — same shape as prompts | P1 |
 | **Quotas** | 5-hour block + weekly panels with ETA and burn rate | P0 |
-| **Privacy** | Four content modes with switch and wipe | P0 |
+| **Privacy** | Three content modes (hash, excerpt, full) with switch and wipe | P0 |
 | **Privacy** | No prompt text in export unless `--include-content` | P0 |
 | **Auth** | Token gate when HOST != localhost | P0 |
 | **Ops** | One-command install, zero network for history | P0 |

--- a/docs-t01-burnmap/mockups/project/uploads/01-prd/05-requirements.md
+++ b/docs-t01-burnmap/mockups/project/uploads/01-prd/05-requirements.md
@@ -18,7 +18,7 @@
 | **Prompts** | Prompt detail: runs list, histogram, outlier flags | P0 |
 | **Tasks** | Same page shape for slash commands, skills, subagent Task calls | P1 |
 | **Quotas** | Claude 5-hour block + weekly panels with ETA and burn rate | P0 |
-| **Privacy** | Four content modes with clean switch and wipe commands | P0 |
+| **Privacy** | Three content modes (hash, excerpt, full) with clean switch and wipe commands | P0 |
 | **Privacy** | No prompt text in any export unless `--include-content` passed | P0 |
 | **Auth** | Token gate when `HOST ≠ localhost` | P0 |
 | **Ops** | One-command install, zero required network access for history | P0 |


### PR DESCRIPTION
Closes #70

## Summary
Clarifies PRD requirement line 21: t01-burnmap implements **three** content modes (hash, excerpt, full), not four. Resolves question issue #70 per decision comment: 'Stay with the current 3. Update PRD.'

## Changes
- Updated both PRD requirement tables (main + mockups) to specify the three modes explicitly
- Removed ambiguity about 4th mode

## Acceptance Criteria
- [x] Tests pass (443/443)
- [x] PRD updated in both locations
- [x] No debug code