### PR TITLE
fix: register all four adapters in _collect_watch_paths

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -27,8 +27,14 @@ def _collect_watch_paths() -> list[str]:
     try:
         from t01_burnmap.adapters.registry import AdapterRegistry
         from t01_burnmap.adapters.claude_code import ClaudeCodeAdapter
+        from t01_burnmap.adapters.codex import CodexAdapter
+        from t01_burnmap.adapters.cline import ClineAdapter
+        from t01_burnmap.adapters.aider import AiderAdapter
         registry = AdapterRegistry()
         registry.register("claude_code", ClaudeCodeAdapter)
+        registry.register("codex", CodexAdapter)
+        registry.register("cline", ClineAdapter)
+        registry.register("aider", AiderAdapter)
         for name in registry.all_names():
             adapter = registry.instantiate(name)
             paths.extend(str(p) for p in adapter.default_paths())


### PR DESCRIPTION
Closes #87

Registers codex, cline, and aider adapters in addition to claude_code adapter, so all four agents are available via the adapter pattern into SQLite.