### PR TITLE
fix: add GET /health endpoint for live checks

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -116,6 +116,10 @@ def create_app() -> FastAPI:
     except ImportError:
         pass
 
+    @app.get("/health", tags=["ops"])
+    def health() -> dict:
+        return {"status": "ok"}
+
     static_dir = Path(__file__).parent / "static"
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,10 @@
+"""Tests for GET /health endpoint."""
+from fastapi.testclient import TestClient
+from burnmap.app import create_app
+
+
+def test_health_returns_ok():
+    client = TestClient(create_app())
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
Closes #85

Adds a simple GET /health endpoint that returns {"status": "ok"} for liveness monitoring. Unblocks discover skill checks and operational readiness requirements.