### PR TITLE
fix: register export router in app.py

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -116,6 +116,13 @@ def create_app() -> FastAPI:
     except ImportError:
         pass
 
+    try:
+        from burnmap.api.export import router as export_router
+        if export_router is not None:
+            app.include_router(export_router)
+    except ImportError:
+        pass
+
     static_dir = Path(__file__).parent / "static"
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")


### PR DESCRIPTION
Closes #84

Registers the missing export router in the FastAPI app initialization, making the GET /api/export endpoint reachable from the UI.