### PR TITLE
fix: add missing web route for provider detail page

### DIFF
--- a/burnmap/api/web.py
+++ b/burnmap/api/web.py
@@ -77,5 +77,9 @@ if _FASTAPI:
     def onboarding(request: Request) -> HTMLResponse:
         return _html(request, "onboarding.html")
 
+    @router.get("/settings/provider/{agent}", response_class=HTMLResponse)
+    def provider_detail(request: Request, agent: str) -> HTMLResponse:
+        return _html(request, "pages/provider_detail.html", agent=agent)
+
 else:
     router = None  # type: ignore[assignment]


### PR DESCRIPTION
Closes #89

Adds GET /settings/provider/{agent} route to serve provider_detail.html with agent context variable. Enables Settings page navigation to provider detail views.