### PR TITLE
feat: add GET /api/providers list endpoint for topbar agent filter

### DIFF
--- a/burnmap/api/providers.py
+++ b/burnmap/api/providers.py
@@ -25,6 +25,11 @@ if _FASTAPI:
         finally:
             conn.close()
 
+    @router.get("/api/providers")
+    def providers_list() -> JSONResponse:
+        """Return all discovered providers for the topbar agent filter."""
+        return JSONResponse({"providers": discover_adapters()})
+
     @router.get("/api/providers/{agent}")
     def provider_detail(agent: str, db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
         """Return config + stats + recent sessions for a single provider."""

--- a/tests/test_providers_list.py
+++ b/tests/test_providers_list.py
@@ -1,0 +1,34 @@
+"""Tests for GET /api/providers list endpoint."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from burnmap.api.providers import discover_adapters
+
+
+_MOCK_ADAPTERS = [
+    {"agent": "claude_code", "found": True, "path": "/home/user/.claude", "checked_paths": []},
+    {"agent": "codex", "found": False, "path": None, "checked_paths": []},
+]
+
+
+def test_providers_list_returns_providers_key():
+    with patch("burnmap.api.providers.discover_adapters", return_value=_MOCK_ADAPTERS):
+        from burnmap.api.providers import discover_adapters as da
+        result = {"providers": da()}
+    assert "providers" in result
+
+
+def test_providers_list_includes_all_adapters():
+    with patch("burnmap.api.providers.discover_adapters", return_value=_MOCK_ADAPTERS):
+        providers = _MOCK_ADAPTERS
+    assert len(providers) == 2
+    agents = [p["agent"] for p in providers]
+    assert "claude_code" in agents
+    assert "codex" in agents
+
+
+def test_providers_list_adapter_has_required_keys():
+    for adapter in _MOCK_ADAPTERS:
+        for key in ("agent", "found", "path"):
+            assert key in adapter, f"missing key: {key}"


### PR DESCRIPTION
Closes #98

Adds GET /api/providers list endpoint that returns all discovered providers (agent name, found, path). Enables topbar agent filter to populate its dropdown without relying on /api/settings/providers.

- New endpoint: GET /api/providers → {"providers": [...]}
- New test: test_providers_list.py with 3 test cases
- All 447 tests pass