### PR TITLE
fix: register export router in app.py

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -119,6 +119,13 @@ def create_app() -> FastAPI:
     except ImportError:
         pass
 
+    try:
+        from burnmap.api.export import router as export_router
+        if export_router is not None:
+            app.include_router(export_router)
+    except ImportError:
+        pass
+
     @app.get("/health", tags=["ops"])
     def health() -> dict:
         return {"status": "ok"}


### PR DESCRIPTION
Closes #84 — re-applies the export router registration cleanly on top of main (PR #100 had unresolvable rebase conflicts).

QA PASSED — 447/447 tests pass, diff verified (same logic as #100).