### PR TITLE
fix: correct adapter import package name from t01_burnmap to burnmap

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -26,11 +26,11 @@ def _collect_watch_paths() -> list[str]:
     """Gather default_paths from all known adapters."""
     paths: list[str] = []
     try:
-        from t01_burnmap.adapters.registry import AdapterRegistry
-        from t01_burnmap.adapters.claude_code import ClaudeCodeAdapter
-        from t01_burnmap.adapters.codex import CodexAdapter
-        from t01_burnmap.adapters.cline import ClineAdapter
-        from t01_burnmap.adapters.aider import AiderAdapter
+        from burnmap.adapters.registry import AdapterRegistry
+        from burnmap.adapters.claude_code import ClaudeCodeAdapter
+        from burnmap.adapters.codex import CodexAdapter
+        from burnmap.adapters.cline import ClineAdapter
+        from burnmap.adapters.aider import AiderAdapter
         registry = AdapterRegistry()
         registry.register("claude_code", ClaudeCodeAdapter)
         registry.register("codex", CodexAdapter)


### PR DESCRIPTION
Closes #121

Fix `_collect_watch_paths` in `app.py`: all five adapter imports used the non-existent `t01_burnmap` package name instead of the actual `burnmap` package. This caused a silent ImportError on every startup, falling back to hardcoded path and making the adapter registry dead code.

## Changes
- `burnmap/app.py`: replace `t01_burnmap.adapters.*` → `burnmap.adapters.*` (5 imports)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>