### PR TITLE
feat: add adapter implementations + registry to burnmap.adapters

### DIFF
--- a/burnmap/adapters/__init__.py
+++ b/burnmap/adapters/__init__.py
@@ -1,3 +1,16 @@
 from .base import BaseAdapter, NormalizedTurn
+from .registry import AdapterRegistry
+from .claude_code import ClaudeCodeAdapter
+from .codex import CodexAdapter
+from .cline import ClineAdapter
+from .aider import AiderAdapter
 
-__all__ = ["BaseAdapter", "NormalizedTurn"]
+__all__ = [
+    "BaseAdapter",
+    "NormalizedTurn",
+    "AdapterRegistry",
+    "ClaudeCodeAdapter",
+    "CodexAdapter",
+    "ClineAdapter",
+    "AiderAdapter",
+]

--- a/burnmap/adapters/aider.py
+++ b/burnmap/adapters/aider.py
@@ -1,0 +1,101 @@
+"""Aider adapter — parses ~/.aider.chat.history.md markdown chat logs."""
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .base import BaseAdapter
+
+# Matches: "# aider chat started at 2024-01-15 10:30:00"
+_SESSION_RE = re.compile(r"^# aider chat started at (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})", re.MULTILINE)
+
+# Matches token lines in two variants:
+#   > Tokens: 1200 sent, 340 received, cost $0.0150 message, ...
+#   > Tokens: 800 sent, 210 received. Cost: $0.0085 message, ...
+_TOKENS_RE = re.compile(
+    r"Tokens:\s+(\d[\d,]*)\s+sent,\s+(\d[\d,]*)\s+received[.,]?\s+[Cc]ost[: \$]+\$([\d.]+)\s+message",
+)
+
+
+def _parse_timestamp(dt_str: str) -> int:
+    """Return milliseconds since epoch for a 'YYYY-MM-DD HH:MM:SS' string."""
+    dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _make_uuid(session_id: str, turn_index: int) -> str:
+    raw = f"{session_id}:{turn_index}"
+    return "aider-" + hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+
+class AiderAdapter(BaseAdapter):
+    """Parses Aider markdown chat history files.
+
+    Aider logs are a single append-only markdown file. Sessions are delimited
+    by '# aider chat started at ...' headings. Each user turn (#### heading)
+    followed by a '> Tokens: ...' line constitutes one turn record.
+    """
+
+    def default_paths(self) -> list[Path]:
+        return [Path.home() / ".aider.chat.history.md"]
+
+    def is_supported_file(self, path: Path) -> bool:
+        return path.name.endswith(".chat.history.md")
+
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        """Parse an Aider markdown history file and return raw turn records."""
+        text = path.read_text(encoding="utf-8", errors="replace")
+        turns: list[dict[str, Any]] = []
+
+        # Split into session blocks by session header
+        session_matches = list(_SESSION_RE.finditer(text))
+        if not session_matches:
+            return turns
+
+        for i, m in enumerate(session_matches):
+            session_dt_str = m.group(1)
+            session_ts = _parse_timestamp(session_dt_str)
+            # Unique session id from timestamp
+            session_id = "aider-" + session_dt_str.replace(" ", "T").replace(":", "-")
+
+            block_start = m.end()
+            block_end = session_matches[i + 1].start() if i + 1 < len(session_matches) else len(text)
+            block = text[block_start:block_end]
+
+            # Find all token lines in this session block
+            for turn_index, tok_match in enumerate(_TOKENS_RE.finditer(block)):
+                sent = int(tok_match.group(1).replace(",", ""))
+                received = int(tok_match.group(2).replace(",", ""))
+                cost = float(tok_match.group(3))
+
+                # Find user prompt: last #### heading before this token line
+                block_before = block[: tok_match.start()]
+                prompt_match = list(re.finditer(r"^####\s+(.+)$", block_before, re.MULTILINE))
+                prompt_text = prompt_match[-1].group(1).strip() if prompt_match else ""
+
+                uid = _make_uuid(session_id, turn_index)
+                turns.append({
+                    "uuid": uid,
+                    "session_id": session_id,
+                    "agent": "aider",
+                    "model": "",          # not present in history file
+                    "timestamp": session_dt_str,
+                    "timestamp_ms": session_ts,
+                    "input_tokens": sent,
+                    "output_tokens": received,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "cost_usd": cost,
+                    "prompt_text": prompt_text,
+                    "tool_uses": [],
+                    "raw": {
+                        "session_id": session_id,
+                        "turn_index": turn_index,
+                        "raw_tokens_line": tok_match.group(0),
+                    },
+                })
+
+        return turns

--- a/burnmap/adapters/claude_code.py
+++ b/burnmap/adapters/claude_code.py
@@ -1,0 +1,81 @@
+"""Claude Code adapter — parses ~/.claude/projects/**/*.jsonl session logs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .base import BaseAdapter
+
+_CLAUDE_GLOB = str(Path.home() / ".claude" / "projects" / "**" / "*.jsonl")
+
+
+class ClaudeCodeAdapter(BaseAdapter):
+    """Parses Claude Code JSONL session files.
+
+    Each line is a JSON record. Only assistant turns with usage data are
+    yielded. Dedup by ``uuid`` (message.id equivalent).
+    """
+
+    def default_paths(self) -> list[Path]:
+        return list(Path.home().glob(".claude/projects/**/*.jsonl"))
+
+    def is_supported_file(self, path: Path) -> bool:
+        return path.suffix == ".jsonl"
+
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        """Return normalised turn records from a Claude Code JSONL file."""
+        seen: set[str] = set()
+        turns: list[dict[str, Any]] = []
+
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                # Only assistant turns with usage carry token data
+                msg = record.get("message") or {}
+                role = msg.get("role") if isinstance(msg, dict) else None
+                if role != "assistant":
+                    continue
+
+                usage = record.get("usage") or {}
+                if not usage:
+                    continue
+
+                uid = record.get("uuid", "")
+                if uid in seen:
+                    continue
+                seen.add(uid)
+
+                # Extract tool uses from message content (list form)
+                tool_uses: list[dict[str, Any]] = []
+                content = msg.get("content", [])
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            tool_uses.append({
+                                "name": block.get("name", ""),
+                                "input": block.get("input", {}),
+                            })
+
+                turns.append({
+                    "uuid": uid,
+                    "session_id": record.get("sessionId", ""),
+                    "agent": "claude_code",
+                    "model": record.get("model", ""),
+                    "timestamp": record.get("timestamp", ""),
+                    "input_tokens": usage.get("input_tokens", 0),
+                    "output_tokens": usage.get("output_tokens", 0),
+                    "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
+                    "cache_write_tokens": usage.get("cache_creation_input_tokens", 0),
+                    "tool_uses": tool_uses,
+                    "raw": record,
+                })
+
+        return turns

--- a/burnmap/adapters/cline.py
+++ b/burnmap/adapters/cline.py
@@ -1,0 +1,65 @@
+"""Cline adapter — parses tasks/*.json task metadata files."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .base import BaseAdapter
+
+_CLINE_GLOB = "tasks/*/task_metadata.json"
+
+
+class ClineAdapter(BaseAdapter):
+    """Parses Cline task metadata JSON files.
+
+    Each ``task_metadata.json`` represents one session/task.
+    Token usage is stored at the task level (tokensIn/tokensOut/cacheWrites/cacheReads).
+    """
+
+    def default_paths(self) -> list[Path]:
+        base = (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Code"
+            / "User"
+            / "globalStorage"
+            / "saoudrizwan.claude-dev"
+        )
+        return list(base.glob(_CLINE_GLOB))
+
+    def is_supported_file(self, path: Path) -> bool:
+        return path.name == "task_metadata.json"
+
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        """Return a single normalised turn record from a Cline task_metadata.json."""
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return []
+
+        task_id = record.get("id", path.parent.name)
+        ts_raw = record.get("ts")
+        timestamp = (
+            datetime.fromtimestamp(ts_raw / 1000, tz=timezone.utc).isoformat()
+            if isinstance(ts_raw, (int, float))
+            else ""
+        )
+
+        return [
+            {
+                "uuid": task_id,
+                "session_id": task_id,
+                "agent": "cline",
+                "model": record.get("modelId", ""),
+                "timestamp": timestamp,
+                "input_tokens": record.get("tokensIn", 0),
+                "output_tokens": record.get("tokensOut", 0),
+                "cache_read_tokens": record.get("cacheReads", 0),
+                "cache_write_tokens": record.get("cacheWrites", 0),
+                "tool_uses": [],
+                "raw": record,
+            }
+        ]

--- a/burnmap/adapters/codex.py
+++ b/burnmap/adapters/codex.py
@@ -1,0 +1,87 @@
+"""Codex CLI adapter — parses ~/.codex/sessions/ JSONL session logs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .base import BaseAdapter
+
+
+class CodexAdapter(BaseAdapter):
+    """Parses Codex CLI JSONL session files.
+
+    Each line is a JSON record. Dedup by ``id`` (turn_id).
+    Supports two record shapes:
+      v1 — flat: prompt_tokens / completion_tokens at top level
+      v2 — nested: usage.prompt_tokens / usage.completion_tokens
+    """
+
+    def default_paths(self) -> list[Path]:
+        return list(Path.home().glob(".codex/sessions/*.jsonl"))
+
+    def is_supported_file(self, path: Path) -> bool:
+        return path.suffix == ".jsonl"
+
+    def parse_file(self, path: Path) -> list[dict[str, Any]]:
+        """Return normalised turn records from a Codex JSONL session file."""
+        seen: set[str] = set()
+        turns: list[dict[str, Any]] = []
+
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if not isinstance(record, dict):
+                    continue
+
+                turn_id = record.get("id", "")
+                if not turn_id:
+                    continue
+                if turn_id in seen:
+                    continue
+                seen.add(turn_id)
+
+                # Token extraction: v2 nested usage, v1 flat
+                usage = record.get("usage") or {}
+                input_tokens = (
+                    usage.get("prompt_tokens")
+                    or record.get("prompt_tokens", 0)
+                )
+                output_tokens = (
+                    usage.get("completion_tokens")
+                    or record.get("completion_tokens", 0)
+                )
+                cache_read_tokens = usage.get("cached_tokens", 0)
+
+                # Tool calls (optional field in some Codex versions)
+                tool_uses: list[dict[str, Any]] = []
+                for tc in record.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        fn = tc.get("function") or {}
+                        tool_uses.append({
+                            "name": fn.get("name", ""),
+                            "input": fn.get("arguments", {}),
+                        })
+
+                turns.append({
+                    "uuid": turn_id,
+                    "session_id": record.get("session_id", ""),
+                    "agent": "codex",
+                    "model": record.get("model", ""),
+                    "timestamp": record.get("created_at", ""),
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cache_read_tokens": cache_read_tokens,
+                    "cache_write_tokens": 0,
+                    "tool_uses": tool_uses,
+                    "raw": record,
+                })
+
+        return turns

--- a/burnmap/adapters/registry.py
+++ b/burnmap/adapters/registry.py
@@ -1,0 +1,28 @@
+"""Adapter registry — discover and load adapters by name."""
+from __future__ import annotations
+from .base import BaseAdapter
+
+
+class AdapterRegistry:
+    """Registry for BaseAdapter implementations."""
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, type[BaseAdapter]] = {}
+
+    def register(self, name: str, adapter_cls: type[BaseAdapter]) -> None:
+        """Register an adapter class under a name."""
+        if not issubclass(adapter_cls, BaseAdapter):
+            raise TypeError(f"{adapter_cls} must subclass BaseAdapter")
+        self._adapters[name] = adapter_cls
+
+    def get(self, name: str) -> type[BaseAdapter]:
+        """Return an adapter class by name. Raises KeyError if not found."""
+        return self._adapters[name]
+
+    def all_names(self) -> list[str]:
+        """Return all registered adapter names."""
+        return list(self._adapters.keys())
+
+    def instantiate(self, name: str) -> BaseAdapter:
+        """Instantiate and return an adapter by name."""
+        return self._adapters[name]()


### PR DESCRIPTION
Closes #122

Copies the existing adapter implementations from `t01_burnmap/adapters/` into `burnmap/adapters/` (the app package used by `app.py`):
- `registry.py` — AdapterRegistry
- `claude_code.py` — ClaudeCodeAdapter
- `codex.py` — CodexAdapter
- `cline.py` — ClineAdapter
- `aider.py` — AiderAdapter
- Updates `__init__.py` to export all classes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>