### PR TITLE
fix: replace PollingObserver with OS-native Observer in watcher

### DIFF
--- a/burnmap/watcher.py
+++ b/burnmap/watcher.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from watchdog.observers.polling import PollingObserver
+from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, FileModifiedEvent, FileCreatedEvent
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class Watcher:
     """Watches adapter log directories and exposes an async event stream."""
 
     def __init__(self) -> None:
-        self._observer: PollingObserver | None = None
+        self._observer: Observer | None = None
         self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self._subscribers: list[asyncio.Queue[dict[str, Any]]] = []
 
@@ -49,7 +49,7 @@ class Watcher:
         """Start the watchdog observer on the given directory paths."""
         loop = asyncio.get_event_loop()
         handler = _LogFileHandler(self._queue, loop)
-        self._observer = PollingObserver()
+        self._observer = Observer()
 
         seen_dirs: set[str] = set()
         for pattern in watch_paths:


### PR DESCRIPTION
Closes #123

Replaces `PollingObserver` (CPU-intensive recursive scan every cycle) with the OS-native `Observer` (FSEvents on macOS, inotify on Linux). This eliminates the 540%+ CPU usage caused by scanning 7686 files in `~/.claude/projects` on every poll.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>