### PR TITLE
fix: promote silent ImportError fallback to logger.warning in app.py

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -40,7 +40,10 @@ def _collect_watch_paths() -> list[str]:
             adapter = registry.instantiate(name)
             paths.extend(str(p) for p in adapter.default_paths())
     except ImportError:
-        logger.debug("No adapters available; using Claude Code default path")
+        logger.warning(
+            "Adapter imports failed; falling back to Claude Code default path. "
+            "Install or fix burnmap.adapters to watch all agent logs."
+        )
         paths.append(str(Path.home() / ".claude" / "projects"))
     return paths
 


### PR DESCRIPTION
Closes #124

Promotes `logger.debug` to `logger.warning` in the `_collect_watch_paths` ImportError fallback. Users on Codex/Cline/Aider will now see a warning in logs when adapters fail to load, rather than silently getting only the Claude Code default path.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>