### PR TITLE
fix: remove fallback to ~/.claude/projects watch path on adapter ImportError

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -41,10 +41,9 @@ def _collect_watch_paths() -> list[str]:
             paths.extend(str(p) for p in adapter.default_paths())
     except ImportError:
         logger.warning(
-            "Adapter imports failed; falling back to Claude Code default path. "
-            "Install or fix burnmap.adapters to watch all agent logs."
+            "Adapter imports failed; no paths will be watched. "
+            "Install or fix burnmap.adapters to watch agent logs."
         )
-        paths.append(str(Path.home() / ".claude" / "projects"))
     return paths
 
 

--- a/burnmap/watcher.py
+++ b/burnmap/watcher.py
@@ -47,7 +47,10 @@ class Watcher:
 
     def start(self, watch_paths: list[str]) -> None:
         """Start the watchdog observer on the given directory paths."""
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.get_event_loop()
         handler = _LogFileHandler(self._queue, loop)
         self._observer = Observer()
 


### PR DESCRIPTION
Drop the 1.2 GB / 7686-file fallback path that pegged CPU at 540% via PollingObserver recursive scan. Watcher now skips watching entirely when adapters fail to import. Also replace deprecated get_event_loop() with get_running_loop() in Watcher.start().

Closes #120