### PR TITLE
fix: deduplicate watcher dirs by resolving file paths to parent

### DIFF
--- a/burnmap/watcher.py
+++ b/burnmap/watcher.py
@@ -67,6 +67,10 @@ class Watcher:
                 concrete.append(part)
             watch_dir = Path(*concrete) if concrete else Path.home()
 
+            # If the resolved path is a file, watch its parent directory
+            if watch_dir.is_file():
+                watch_dir = watch_dir.parent
+
             if not watch_dir.exists():
                 logger.debug("Skipping non-existent watch path: %s", watch_dir)
                 continue


### PR DESCRIPTION
## Problem

`Watcher.start()` was scheduling one PollingObserver watch per path item. When `ClaudeCodeAdapter.default_paths()` returns 3441 individual `.jsonl` files, the `seen_dirs` dedup set had no effect (each file path is unique). Result: 3441 separate watches → observer startup hangs event loop.

## Fix

After resolving concrete path segments, if the result is a file (not a directory), use its parent. Reduces unique watch count from 3441 → 182 (one per session directory).

Server now starts and responds to `/health` within ~20s, unblocking discover skill's live audit.

## Evidence

- Before: 3441 watches, server never responds  
- After: 182 watches, server responds to GET /health in ~20s

Closes #127