### PR TITLE
fix(prompts): show prompt text snippets instead of '(no text)'

### DIFF
--- a/burnmap/api/prompts.py
+++ b/burnmap/api/prompts.py
@@ -53,15 +53,24 @@ else:
 _VALID_SORTS = {"cost", "runs", "tokens", "recent"}
 
 
-def _has_content_db(conn: sqlite3.Connection) -> bool:
-    """Return True if the content DB is attached and has the prompt_content table."""
+def _get_content_table_ref(conn: sqlite3.Connection) -> str | None:
+    """Return 'prompt_content' if in main DB, 'content_db.prompt_content' if attached, else None."""
+    # Check main DB first (for tests and fallback)
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='prompt_content'"
+    ).fetchone()
+    if row is not None:
+        return "prompt_content"
+    # Check attached content_db (production)
     try:
         row = conn.execute(
             "SELECT 1 FROM content_db.sqlite_master WHERE type='table' AND name='prompt_content'"
         ).fetchone()
-        return row is not None
+        if row is not None:
+            return "content_db.prompt_content"
     except sqlite3.OperationalError:
-        return False
+        pass
+    return None
 
 
 def query_prompts(
@@ -82,15 +91,15 @@ def query_prompts(
     }
     order = order_map[sort]
 
-    has_content = _has_content_db(conn)
-    content_join = "LEFT JOIN content_db.prompt_content pc ON pc.fingerprint = p.fingerprint" if has_content else ""
-    snippet_expr = "COALESCE(SUBSTR(pc.content, 1, 120), '(no text)')" if has_content else "'(no text)'"
+    content_tbl = _get_content_table_ref(conn)
+    content_join = f"LEFT JOIN {content_tbl} pc ON pc.fingerprint = p.fingerprint" if content_tbl else ""
+    snippet_expr = "COALESCE(SUBSTR(pc.content, 1, 120), '(no text)')" if content_tbl else "'(no text)'"
 
     where_clauses: list[str] = []
     params: list[Any] = []
 
     if search:
-        if has_content:
+        if content_tbl:
             where_clauses.append("(pc.content LIKE ? OR p.fingerprint LIKE ?)")
             params.extend([f"%{search}%", f"%{search}%"])
         else:
@@ -136,9 +145,9 @@ def query_prompt_detail(
     fingerprint: str,
 ) -> dict[str, Any] | None:
     """Return prompt detail: text, stats, run histogram, outlier flags, run list."""
-    has_content = _has_content_db(conn)
-    content_join = "LEFT JOIN content_db.prompt_content pc ON pc.fingerprint = p.fingerprint" if has_content else ""
-    content_expr = "COALESCE(pc.content, '(no text)')" if has_content else "'(no text)'"
+    content_tbl = _get_content_table_ref(conn)
+    content_join = f"LEFT JOIN {content_tbl} pc ON pc.fingerprint = p.fingerprint" if content_tbl else ""
+    content_expr = "COALESCE(pc.content, '(no text)')" if content_tbl else "'(no text)'"
     row = conn.execute(
         f"""
         SELECT

--- a/burnmap/api/prompts.py
+++ b/burnmap/api/prompts.py
@@ -53,11 +53,15 @@ else:
 _VALID_SORTS = {"cost", "runs", "tokens", "recent"}
 
 
-def _has_table(conn: sqlite3.Connection, name: str) -> bool:
-    row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
-    ).fetchone()
-    return row is not None
+def _has_content_db(conn: sqlite3.Connection) -> bool:
+    """Return True if the content DB is attached and has the prompt_content table."""
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM content_db.sqlite_master WHERE type='table' AND name='prompt_content'"
+        ).fetchone()
+        return row is not None
+    except sqlite3.OperationalError:
+        return False
 
 
 def query_prompts(
@@ -78,8 +82,8 @@ def query_prompts(
     }
     order = order_map[sort]
 
-    has_content = _has_table(conn, "prompt_content")
-    content_join = "LEFT JOIN prompt_content pc ON pc.fingerprint = p.fingerprint" if has_content else ""
+    has_content = _has_content_db(conn)
+    content_join = "LEFT JOIN content_db.prompt_content pc ON pc.fingerprint = p.fingerprint" if has_content else ""
     snippet_expr = "COALESCE(SUBSTR(pc.content, 1, 120), '(no text)')" if has_content else "'(no text)'"
 
     where_clauses: list[str] = []
@@ -132,8 +136,8 @@ def query_prompt_detail(
     fingerprint: str,
 ) -> dict[str, Any] | None:
     """Return prompt detail: text, stats, run histogram, outlier flags, run list."""
-    has_content = _has_table(conn, "prompt_content")
-    content_join = "LEFT JOIN prompt_content pc ON pc.fingerprint = p.fingerprint" if has_content else ""
+    has_content = _has_content_db(conn)
+    content_join = "LEFT JOIN content_db.prompt_content pc ON pc.fingerprint = p.fingerprint" if has_content else ""
     content_expr = "COALESCE(pc.content, '(no text)')" if has_content else "'(no text)'"
     row = conn.execute(
         f"""

--- a/burnmap/db/schema.py
+++ b/burnmap/db/schema.py
@@ -107,13 +107,21 @@ _CONTENT_SCHEMA_SQL = """
 
 
 def get_db(path: str | Path | None = None) -> sqlite3.Connection:
-    """Return an open WAL-mode SQLite connection (main DB)."""
+    """Return an open WAL-mode SQLite connection (main DB).
+
+    If the content DB file exists it is attached as ``content_db`` so that
+    ``prompt_content`` is reachable via JOIN without a separate connection.
+    The attachment is optional — deleting the file reverts queries to '(no text)'.
+    """
     db_path = Path(path) if path else _DEFAULT_DB
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
+    content_db_path = _CONTENT_DB if path is None else Path(path).parent / "content.db"
+    if content_db_path.exists():
+        conn.execute(f"ATTACH DATABASE ? AS content_db", (str(content_db_path),))
     return conn
 
 

--- a/burnmap/templates/base.html
+++ b/burnmap/templates/base.html
@@ -149,7 +149,7 @@
     <!-- Content-mode info banner -->
     <div class="banner banner--info" x-show="showBanner">
       <svg viewBox="0 0 14 14" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.3"><circle cx="7" cy="7" r="4.5"/><path d="M7 6.5v3M7 5v.01" stroke-linecap="round"/></svg>
-      <span>Content mode active — prompt text is stored locally and never sent to any remote service.</span>
+      <span x-text="contentModeBannerText"></span>
       <button class="banner__close" @click="showBanner = false" aria-label="Dismiss">
         <svg viewBox="0 0 14 14" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 3l8 8M11 3l-8 8"/></svg>
       </button>
@@ -177,8 +177,16 @@ function shell() {
       { id: 'aider',      label: 'Aider' },
     ],
     showBanner: true,
+    contentModeBannerText: 'Content mode: fingerprint_only — prompt text is NOT stored. Change in Settings to enable.',
 
-    init() {
+    _contentModeBannerMessages: {
+      'off':              'Content mode: off — prompt text collection is disabled.',
+      'fingerprint_only': 'Content mode: fingerprint_only — prompt text is NOT stored. Change in Settings to enable.',
+      'preview':          'Content mode: preview — first 512 chars of each prompt are stored locally and never sent to any remote service.',
+      'full':             'Content mode: full — prompt text is stored locally and never sent to any remote service.',
+    },
+
+    async init() {
       // Derive active page from URL path
       const path = window.location.pathname.replace(/^\//, '') || 'overview';
       this.page = path.split('/')[0];
@@ -186,6 +194,14 @@ function shell() {
       // Expose agentFilter globally so page scripts can read it
       window.__burnmapShell = this;
 
+      // Fetch real content mode to show accurate banner
+      try {
+        const r = await fetch('/api/content/mode');
+        if (r.ok) {
+          const data = await r.json();
+          this.contentModeBannerText = this._contentModeBannerMessages[data.mode] || `Content mode: ${data.mode}`;
+        }
+      } catch (_) { /* keep default */ }
     },
 
     setAgentFilter(id) {

--- a/burnmap/templates/pages/settings.html
+++ b/burnmap/templates/pages/settings.html
@@ -228,16 +228,18 @@ function settingsPage() {
         } catch { return null; }
       };
       try {
-        const [stor, prov, price, bf] = await Promise.all([
+        const [stor, prov, price, bf, cm] = await Promise.all([
           safeJson('/api/settings/storage'),
           safeJson('/api/settings/providers'),
           safeJson('/api/settings/pricing'),
           safeJson('/api/backfill'),
+          safeJson('/api/content/mode'),
         ]);
         this.storage = stor;
         this.providers = (prov && prov.providers) || [];
         this.pricing = price;
         this.backfill = bf;
+        if (cm && cm.mode) this.selectedMode = cm.mode;
       } finally {
         this.loading = false;
       }
@@ -248,14 +250,23 @@ function settingsPage() {
       return [{ label: 'PATH', value: this.storage.path }];
     },
 
-    applyMode() {
-      // POST to /api/settings/content-mode when backend endpoint exists
-      console.log('apply content mode:', this.selectedMode);
+    async applyMode() {
+      const r = await fetch('/api/settings/content-mode', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: this.selectedMode }),
+      });
+      if (!r.ok) alert('Failed to apply content mode.');
     },
 
-    wipeContent() {
+    async wipeContent() {
       if (!confirm('Wipe all stored prompt content? This cannot be undone.')) return;
-      console.log('wipe content');
+      const r = await fetch('/api/wipe', { method: 'POST' });
+      if (r.ok) {
+        await this.load();
+      } else {
+        alert('Wipe failed.');
+      }
     },
 
     async syncPricing() {


### PR DESCRIPTION
Closes #139

## Changes
- `get_db()` attaches content.db as content_db when file exists (detachable as per PRD)
- `_get_content_table_ref()` detects table location (main DB for tests, content_db for prod)
- All queries use correct table reference in JOINs
- `base.html` banner fetches real content mode + shows accurate wording per mode
- `settings.html` wires applyMode/wipeContent to API; loads current mode on init

## Test coverage
All 447 tests pass including content search test.