### PR TITLE
fix(ingest): call compute_cost when span cost_usd is zero

### DIFF
--- a/burnmap/api/backfill.py
+++ b/burnmap/api/backfill.py
@@ -16,6 +16,7 @@ except ImportError:
 
 from burnmap.db.schema import get_db
 from burnmap.fingerprint import insert_prompt_run, upsert_prompt
+from burnmap.pricing import compute_cost, lookup_rates
 
 if _FASTAPI:
     router = APIRouter()
@@ -135,9 +136,17 @@ def build_spans_from_record(
     turn_id = record.get("uuid") or record.get("id") or str(uuid.uuid4())
     input_tokens = int(usage.get("input_tokens") or 0)
     output_tokens = int(usage.get("output_tokens") or 0)
+    cache_read_tokens = int(
+        usage.get("cache_read_input_tokens") or usage.get("cached_tokens") or 0
+    )
     cost = float(record.get("costUSD") or record.get("cost_usd") or 0.0)
+    model = record.get("model") or ""
     ts = _ts_ms(record.get("timestamp") or record.get("ts"))
     turn_name = record.get("name") or "turn"
+
+    # Compute cost from tokens when the log doesn't record it directly
+    if cost == 0.0 and (input_tokens or output_tokens) and model:
+        cost = compute_cost(model, input_tokens, output_tokens, cache_read_tokens)
 
     spans: list[dict[str, Any]] = [{
         "id": turn_id,

--- a/tests/test_span_tree.py
+++ b/tests/test_span_tree.py
@@ -132,6 +132,26 @@ class TestBuildSpansFromRecord:
         spans = build_spans_from_record(rec, "sess-1", "claude_code")
         assert spans == []
 
+    def test_cost_computed_from_tokens_when_zero(self):
+        """When costUSD=0 but tokens+model present, compute_cost fills cost_usd."""
+        rec = self._record(costUSD=0.0, model="claude-3-5-sonnet-20241022")
+        rec["usage"] = {"input_tokens": 1000, "output_tokens": 500}
+        spans = build_spans_from_record(rec, "sess-1", "claude_code")
+        assert spans[0]["cost_usd"] > 0.0
+
+    def test_cost_not_overridden_when_nonzero(self):
+        """When costUSD is already set, don't override it."""
+        rec = self._record(costUSD=0.05, model="claude-3-5-sonnet-20241022")
+        spans = build_spans_from_record(rec, "sess-1", "claude_code")
+        assert spans[0]["cost_usd"] == 0.05
+
+    def test_cost_zero_when_no_model(self):
+        """When model is missing, cost stays 0 (no spurious fallback pricing)."""
+        rec = self._record(costUSD=0.0)
+        rec["usage"] = {"input_tokens": 1000, "output_tokens": 500}
+        spans = build_spans_from_record(rec, "sess-1", "claude_code")
+        assert spans[0]["cost_usd"] == 0.0
+
 
 # ── Tree reconstruction from fixture JSONL ──────────────────────────────────
 


### PR DESCRIPTION
Closes #138

## What

`compute_cost()` was defined but never called. Claude Code, Codex, and Cline logs record token counts but not cost, so every span had `cost_usd = 0.0`.

## Fix

In `build_spans_from_record`: extract `model` and `cache_read_tokens` from the record, then call `compute_cost(model, input, output, cache_read)` when `cost_usd == 0` and tokens + model are present.

Aider (which logs cost directly) is unaffected — its `costUSD` is non-zero so the branch is skipped.

## Tests

Three new unit tests in `test_span_tree.py`:
- cost computed from tokens when zero
- cost not overridden when non-zero
- cost stays zero when model is missing