### PR TITLE
fix(prompts): read tokens/cost from assistant record, not user record

### DIFF
--- a/burnmap/api/backfill.py
+++ b/burnmap/api/backfill.py
@@ -1,10 +1,13 @@
 """/api/backfill — ingest all pre-existing JSONL/log files on first run."""
 from __future__ import annotations
 
+import logging
 import sqlite3
 import uuid
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 try:
     from fastapi import APIRouter, Depends
@@ -227,13 +230,14 @@ def _extract_user_text(record: dict[str, Any]) -> str:
 
 def _ingest_prompt_record(
     conn: sqlite3.Connection,
-    record: dict[str, Any],
+    user_record: dict[str, Any],
+    asst_record: dict[str, Any],
     session_id: str,
     agent: str,
     path: Path,
 ) -> None:
-    """Fingerprint a user-role record and write to prompts + prompt_runs."""
-    text = _extract_user_text(record)
+    """Fingerprint a user-role record using token/cost from the paired assistant record."""
+    text = _extract_user_text(user_record)
     if not text:
         return
 
@@ -243,14 +247,23 @@ def _ingest_prompt_record(
     except Exception:
         content_mode = "fingerprint_only"
 
-    # Derive project name from the grandparent directory of the JSONL file
     project = path.parent.name if path.parent else ""
 
-    ts = _ts_ms(record.get("timestamp") or record.get("ts"))
-    turn_id = record.get("uuid") or record.get("id")
-    usage = record.get("usage") or {}
-    input_tokens = int(usage.get("input_tokens") or 0)
-    cost_usd = float(record.get("costUSD") or record.get("cost_usd") or 0.0)
+    ts = _ts_ms(user_record.get("timestamp") or user_record.get("ts"))
+    turn_id = user_record.get("uuid") or user_record.get("id")
+
+    # Read tokens/cost from the assistant record (usage may be top-level or inside message)
+    asst_msg = asst_record.get("message") or {}
+    asst_usage = asst_record.get("usage") or (asst_msg.get("usage") if isinstance(asst_msg, dict) else None) or {}
+    input_tokens = int(asst_usage.get("input_tokens") or 0)
+    output_tokens = int(asst_usage.get("output_tokens") or 0)
+    cache_read_tokens = int(
+        asst_usage.get("cache_read_input_tokens") or asst_usage.get("cached_tokens") or 0
+    )
+    cost_usd = float(asst_record.get("costUSD") or asst_record.get("cost_usd") or 0.0)
+    model = asst_record.get("model") or ""
+    if cost_usd == 0.0 and (input_tokens or output_tokens) and model:
+        cost_usd = compute_cost(model, input_tokens, output_tokens, cache_read_tokens)
 
     fp = upsert_prompt(
         conn,
@@ -284,6 +297,8 @@ def _ingest_jsonl_file(conn: sqlite3.Connection, agent: str, path: Path) -> int:
     session_ids_seen: set[str] = set()
     # Track per-session min/max timestamps to populate started_at/ended_at
     session_ts: dict[str, tuple[int, int]] = {}  # session_id -> (min_ts, max_ts)
+    # Buffer last user record per session for prompt pairing with assistant record
+    pending_user: dict[str, dict[str, Any]] = {}  # session_id -> user record
 
     with open(path, encoding="utf-8", errors="replace") as fh:
         for line in fh:
@@ -300,7 +315,7 @@ def _ingest_jsonl_file(conn: sqlite3.Connection, agent: str, path: Path) -> int:
             if not session_id:
                 continue  # drop path-fallback rows; don't materialize dead sessions
 
-            # Ensure session row exists (dedup)
+            # Ensure session row exists BEFORE any prompt ingestion (FK requirement)
             if session_id not in existing_sessions and session_id not in session_ids_seen:
                 conn.execute(
                     "INSERT OR IGNORE INTO sessions (id, agent, started_at, ended_at) VALUES (?,?,0,0)",
@@ -317,11 +332,23 @@ def _ingest_jsonl_file(conn: sqlite3.Connection, agent: str, path: Path) -> int:
                 else:
                     session_ts[session_id] = (min(prev[0], ts), max(prev[1], ts))
 
-            # Prompt ingestion: extract user-role text blocks and fingerprint them
-            try:
-                _ingest_prompt_record(conn, record, session_id, agent, path)
-            except Exception:
-                pass  # prompts table may not exist on legacy schema
+            msg = record.get("message") or {}
+            role = msg.get("role") if isinstance(msg, dict) else None
+
+            if role == "user":
+                # Buffer user record — will be paired with the next assistant record
+                if _extract_user_text(record):
+                    pending_user[session_id] = record
+            elif role == "assistant":
+                # Pair with buffered user record from same session
+                user_rec = pending_user.pop(session_id, None)
+                if user_rec is not None:
+                    try:
+                        _ingest_prompt_record(conn, user_rec, record, session_id, agent, path)
+                    except sqlite3.OperationalError:
+                        pass  # legacy schema without prompts/prompt_runs table
+                    except Exception as exc:
+                        logger.warning("prompt ingest failed: %s", exc, exc_info=True)
 
             for span in build_spans_from_record(record, session_id, agent):
                 conn.execute(

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -45,6 +45,25 @@ def conn(tmp_path):
             ended_at INTEGER DEFAULT 0,
             is_outlier INTEGER DEFAULT 0
         );
+        CREATE TABLE prompts (
+            fingerprint TEXT PRIMARY KEY,
+            first_seen INTEGER DEFAULT 0,
+            last_seen INTEGER DEFAULT 0,
+            run_count INTEGER DEFAULT 0,
+            total_tokens INTEGER DEFAULT 0,
+            total_cost REAL DEFAULT 0.0,
+            agents TEXT DEFAULT '',
+            projects TEXT DEFAULT ''
+        );
+        CREATE TABLE prompt_runs (
+            id TEXT PRIMARY KEY,
+            fingerprint TEXT NOT NULL REFERENCES prompts(fingerprint),
+            session_id TEXT NOT NULL REFERENCES sessions(id),
+            turn_id TEXT,
+            ts INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0.0
+        );
     """)
     return db
 
@@ -65,6 +84,14 @@ def _make_turn(session_id: str, uid: str | None = None, input_tokens: int = 100)
             "usage": {"input_tokens": input_tokens, "output_tokens": 50},
         },
         "costUSD": 0.01,
+    }
+
+
+def _make_user(session_id: str, text: str = "hello world", uid: str | None = None) -> dict:
+    return {
+        "uuid": uid or str(uuid.uuid4()),
+        "sessionId": session_id,
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
     }
 
 
@@ -123,6 +150,63 @@ class TestIngestJsonlFile:
         p.write_text('{"valid": 1, "sessionId": "s1", "message": {"usage": {"input_tokens": 10, "output_tokens": 5}}}\nnot-json\n')
         count = _ingest_jsonl_file(conn, "claude_code", p)
         assert count == 1
+
+
+# ── Prompt pairing (tokens/cost from assistant record) ────────────────────────
+
+class TestPromptIngestion:
+    def test_prompt_run_created_with_assistant_tokens(self, conn, tmp_path):
+        """User prompt gets tokens attributed from the following assistant record."""
+        f = _write_jsonl(tmp_path / "sess.jsonl", [
+            _make_user("s1", "what is two plus two"),
+            _make_turn("s1", input_tokens=300),
+        ])
+        _ingest_jsonl_file(conn, "claude_code", f)
+        row = conn.execute("SELECT SUM(input_tokens) AS t FROM prompt_runs").fetchone()
+        assert row["t"] == 300  # from assistant record, not 0 from user record
+
+    def test_prompt_total_tokens_non_zero(self, conn, tmp_path):
+        f = _write_jsonl(tmp_path / "sess.jsonl", [
+            _make_user("s1", "what is two plus two"),
+            _make_turn("s1", input_tokens=300),
+        ])
+        _ingest_jsonl_file(conn, "claude_code", f)
+        row = conn.execute("SELECT SUM(total_tokens) AS t FROM prompts").fetchone()
+        assert row["t"] == 300
+
+    def test_prompt_run_count(self, conn, tmp_path):
+        """Two user/assistant pairs → two prompt_runs."""
+        f = _write_jsonl(tmp_path / "sess.jsonl", [
+            _make_user("s1", "first question"),
+            _make_turn("s1"),
+            _make_user("s1", "second question"),
+            _make_turn("s1"),
+        ])
+        _ingest_jsonl_file(conn, "claude_code", f)
+        count = conn.execute("SELECT COUNT(*) AS n FROM prompt_runs").fetchone()["n"]
+        assert count == 2
+
+    def test_user_without_assistant_not_inserted(self, conn, tmp_path):
+        """User record at end of file with no following assistant → no prompt_run."""
+        f = _write_jsonl(tmp_path / "sess.jsonl", [
+            _make_user("s1", "orphaned question"),
+        ])
+        _ingest_jsonl_file(conn, "claude_code", f)
+        count = conn.execute("SELECT COUNT(*) AS n FROM prompt_runs").fetchone()["n"]
+        assert count == 0
+
+    def test_session_inserted_before_prompt_run(self, conn, tmp_path):
+        """FK constraint: session row must exist before prompt_run insert."""
+        f = _write_jsonl(tmp_path / "sess.jsonl", [
+            _make_user("new-session", "hello"),
+            _make_turn("new-session", input_tokens=100),
+        ])
+        # Should not raise FK constraint error
+        _ingest_jsonl_file(conn, "claude_code", f)
+        session = conn.execute("SELECT id FROM sessions WHERE id='new-session'").fetchone()
+        assert session is not None
+        runs = conn.execute("SELECT COUNT(*) AS n FROM prompt_runs").fetchone()["n"]
+        assert runs == 1
 
 
 # ── run_backfill ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes per-prompt token/cost being 0 and prompt_runs being empty.

**Root causes:**
1. _ingest_prompt_record was reading usage from the user record (always empty) — tokens/cost live on the assistant record
2. Session row was inserted after _ingest_prompt_record, causing FK failure on prompt_runs.session_id
3. except Exception: pass silently swallowed all errors

**Fix:**
- Buffer user records per session; flush when paired assistant record arrives
- Move session insert before prompt ingestion (satisfies FK)
- Replace bare except pass with sqlite3.OperationalError catch + logger.warning for unexpected errors

Closes #143