### PR TITLE
docs(prd): reduce content modes from four to two

### DIFF
--- a/docs-t01-burnmap/01-prd/02-scope.md
+++ b/docs-t01-burnmap/01-prd/02-scope.md
@@ -8,7 +8,7 @@
 - **Tree reconstruction** — OpenTelemetry-aligned spans (prompt -> turn -> tool -> subagent -> recurse).
 - **Icicle + indented tree views** — two complementary visualizations, synced selection.
 - **Attribution labels** — `exact` / `apportioned` / `inherited` as colored badges (green / amber / gray) on each span.
-- **Content-mode privacy** — four modes (`off`, `fingerprint_only`, `preview`, `full`). One-command wipe.
+- **Content-mode privacy** — two modes (`preview` default, `full` opt-in). SHA-256 fingerprint always stored. One-command wipe drops snippets; fingerprints and aggregates are preserved.
 - **Cost estimation** — effective-dated LiteLLM pricing. Subscription runs labeled synthetic, API runs labeled real.
 - **Quota panels** — Claude 5-hour block + weekly progress bars. Pro / Max5 / Max20 / Custom. P90 auto-detect.
 - **Live tailer** — watchdog + SSE, sub-second refresh.

--- a/docs-t01-burnmap/01-prd/04-usage-scenarios.md
+++ b/docs-t01-burnmap/01-prd/04-usage-scenarios.md
@@ -16,6 +16,6 @@ Nine scenarios driving the v1 feature set.
 
 - **Duplicate-prompt discovery.** Same prompt typed 23 times this month. Convert into slash command or skill.
 
-- **Privacy wipe.** `t01-burnmap content wipe` clears stored prompt text, keeps fingerprints and aggregates.
+- **Privacy wipe.** `t01-burnmap content wipe` clears stored prompt snippets (preview text or full text), keeps fingerprints and aggregates intact.
 
 - **First-run setup.** Install via `pipx install t01-burnmap`, run `t01-burnmap serve`. Onboarding screen discovers adapters, backfills pre-existing JSONL, lands on Overview.

--- a/docs-t01-burnmap/01-prd/05-requirements.md
+++ b/docs-t01-burnmap/01-prd/05-requirements.md
@@ -18,7 +18,7 @@
 | **Prompts** | Detail: runs list, histogram, outlier flags | P0 |
 | **Tasks** | Slash commands, skills, subagent calls — same shape as prompts | P1 |
 | **Quotas** | 5-hour block + weekly panels with ETA and burn rate | P0 |
-| **Privacy** | Three content modes (hash, excerpt, full) with switch and wipe | P0 |
+| **Privacy** | Two content modes (`preview`: first 5 words + fingerprint, `full`: complete text + fingerprint) with switch and wipe | P0 |
 | **Privacy** | No prompt text in export unless `--include-content` | P0 |
 | **Auth** | Token gate when HOST != localhost | P0 |
 | **Ops** | One-command install, zero network for history | P0 |


### PR DESCRIPTION
Closes #144

Changes:
- 02-scope.md: Updated from four modes to two (preview default, full opt-in)
- 04-usage-scenarios.md: Privacy wipe scenario clarifies fingerprints/aggregates preserved
- 05-requirements.md: Updated privacy requirement to two modes with specifications