### PR TITLE
fix: add GET /api/settings aggregate endpoint

### DIFF
--- a/burnmap/api/settings.py
+++ b/burnmap/api/settings.py
@@ -27,6 +27,15 @@ if _FASTAPI:
         finally:
             conn.close()
 
+    @router.get("/api/settings")
+    def aggregate_settings() -> JSONResponse:
+        """Aggregate settings for the export page: content_mode + pricing metadata."""
+        from burnmap.api.content import get_content_mode
+        return JSONResponse({
+            "content_mode": get_content_mode(),
+            "pricing": query_pricing_info(),
+        })
+
     @router.get("/api/settings/storage")
     def storage_info(db: sqlite3.Connection = Depends(_db)) -> JSONResponse:
         return JSONResponse(query_storage_info(db))


### PR DESCRIPTION
Closes #151

Adds bare `GET /api/settings` endpoint returning content_mode + pricing metadata for export.html.

## Changes
- Add `GET /api/settings` aggregate endpoint in burnmap/api/settings.py
- Returns: {content_mode, pricing} — what export.html expects
- All 452 tests pass

## Acceptance criteria
- [x] Endpoint returns content_mode field
- [x] No conflicts with sub-paths (/api/settings/storage, etc)
- [x] Tests pass