### PR TITLE
fix: add /trace/{trace_id} handler + pass trace context

### DIFF
--- a/burnmap/api/web.py
+++ b/burnmap/api/web.py
@@ -68,9 +68,39 @@ if _FASTAPI:
     def tasks(request: Request) -> HTMLResponse:
         return _html(request, "pages/tasks.html")
 
+    @router.get("/trace/{trace_id}", response_class=HTMLResponse)
+    def trace_detail(request: Request, trace_id: str) -> HTMLResponse:
+        """Render trace detail page for a specific trace/session."""
+        from burnmap.api.trace import query_trace
+        from burnmap.db.schema import get_db
+        db = get_db()
+        try:
+            trace = query_trace(db, trace_id)
+            if trace is None:
+                from fastapi import HTTPException
+                raise HTTPException(status_code=404, detail="Trace not found")
+            return _html(request, "pages/trace_tree.html", trace=trace)
+        finally:
+            db.close()
+
     @router.get("/trace", response_class=HTMLResponse)
     def trace(request: Request) -> HTMLResponse:
-        return _html(request, "pages/trace_tree.html")
+        """Render trace list/index page. Redirects to first trace or shows empty state."""
+        from burnmap.db.schema import get_db
+        db = get_db()
+        try:
+            # Get first session to show its trace
+            row = db.execute("SELECT id FROM sessions ORDER BY started_at DESC LIMIT 1").fetchone()
+            if row:
+                session_id = row[0]
+                from burnmap.api.trace import query_trace
+                trace = query_trace(db, session_id)
+                if trace:
+                    return _html(request, "pages/trace_tree.html", trace=trace)
+            # Fallback: render with empty trace
+            return _html(request, "pages/trace_tree.html", trace={"id": None, "label": "No traces", "total_tokens": 0, "total_cost": 0, "turns": 0, "tools": 0, "tree": []})
+        finally:
+            db.close()
 
     @router.get("/tools", response_class=HTMLResponse)
     def tools(request: Request) -> HTMLResponse:

--- a/burnmap/templates/pages/trace_tree.html
+++ b/burnmap/templates/pages/trace_tree.html
@@ -84,7 +84,7 @@
 
   {# ── Trace header ─────────────────────────────────────────────── #}
   <div class="row" style="margin-bottom: 6px; font-family: var(--font-mono); font-size: 11.5px; color: var(--ink-3);">
-    <a href="/traces" class="btn btn--ghost">← back</a>
+    <a href="/trace" class="btn btn--ghost">← back</a>
     <span>trace <b style="color: var(--ink);">{{ trace.id }}</b></span>
     <span class="spacer"></span>
     <span>{{ trace.total_tokens | int | format_tok }} tokens</span>


### PR DESCRIPTION
Closes #150 #149

Fixes two trace routing bugs:
- Issue #149: GET /trace returned HTTP 500 (UndefinedError: trace not in context)
- Issue #150: GET /trace/{trace_id} returned 404 (no handler registered)

## Changes
- Add `GET /trace/{trace_id}` handler with session/trace lookup
- Fix `GET /trace` handler to pass trace context (loads latest session)
- Fix template back link from /traces (unrouted) to /trace
- Fallback rendering with empty trace if no session found

## Acceptance criteria
- [x] /trace/{trace_id} handler returns 200 with trace data
- [x] /trace handler returns 200 with latest trace context
- [x] No UndefinedError in template
- [x] All 452 tests pass