### PR TITLE
fix: add duration_ms and tree keys to query_trace (#154)

### DIFF
--- a/burnmap/api/trace.py
+++ b/burnmap/api/trace.py
@@ -61,6 +61,11 @@ def _build_tree(
         node = dict(s)
         node["children"] = []
         node["attribution"] = _attribution(s.get("kind", ""))
+        # Normalise to template-expected aliases
+        node["label"] = s.get("name", "")
+        node["tokens"] = s.get("input_tokens", 0) + s.get("output_tokens", 0)
+        node["cost"] = s.get("cost_usd", 0.0)
+        node["loop"] = False
         by_id[s["id"]] = node
 
     roots: list[dict[str, Any]] = []
@@ -134,13 +139,30 @@ def query_trace(
     total_tokens = sum(s.get("input_tokens", 0) + s.get("output_tokens", 0) for s in spans)
     total_cost = sum(s.get("cost_usd", 0.0) for s in spans)
 
+    started_at = session.get("started_at") or 0
+    ended_at = session.get("ended_at") or 0
+    duration_ms = max(0, ended_at - started_at)
+    tree = {
+        "id": session_id,
+        "label": session.get("agent") or session_id,
+        "kind": "session",
+        "tokens": total_tokens,
+        "cost": round(total_cost, 6),
+        "loop": False,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "children": collapsed_roots,
+    }
+
     return {
         "session_id": session_id,
         "agent": session.get("agent"),
-        "started_at": session.get("started_at"),
-        "ended_at": session.get("ended_at"),
+        "started_at": started_at,
+        "ended_at": ended_at,
         "total_tokens": total_tokens,
         "total_cost": round(total_cost, 6),
         "span_count": len(spans),
         "roots": collapsed_roots,
+        "duration_ms": duration_ms,
+        "tree": tree,
     }

--- a/tests/test_trace_api.py
+++ b/tests/test_trace_api.py
@@ -175,6 +175,18 @@ class TestQueryTrace:
         root = result["roots"][0]
         assert root["attribution"] == "exact"  # turn → exact
 
+    def test_duration_ms_present(self, seeded_db):
+        result = query_trace(seeded_db, _SID)
+        # ended_at - started_at = 1_700_001_000_000 - 1_700_000_000_000 = 1_000_000
+        assert result["duration_ms"] == 1_000_000
+
+    def test_tree_present_with_started_at_and_children(self, seeded_db):
+        result = query_trace(seeded_db, _SID)
+        assert "tree" in result
+        tree = result["tree"]
+        assert tree["started_at"] == result["started_at"]
+        assert tree["children"] is result["roots"]
+
 
 # ── Template rendering ────────────────────────────────────────────────────────
 
@@ -271,3 +283,45 @@ class TestTraceTreeTemplate:
         # No children, but renders without error
         assert "icicle-bar" in out
         assert "indent-row" in out
+
+
+# ── Smoke: query_trace output renders the trace_tree template without error ───
+
+_WEB_SID = str(uuid.uuid4())
+
+
+def _seed_web(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "INSERT INTO sessions (id, agent, started_at, ended_at) VALUES (?,?,?,?)",
+        (_WEB_SID, "claude_code", 1_700_000_000_000, 1_700_001_000_000),
+    )
+    conn.execute(
+        "INSERT INTO spans (id, session_id, agent, kind, name, parent_id, "
+        "input_tokens, output_tokens, cost_usd, started_at, ended_at, is_outlier) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        (str(uuid.uuid4()), _WEB_SID, "claude_code", "turn", "root", None, 100, 50, 0.001,
+         1_700_000_000_000, 1_700_001_000_000, 0),
+    )
+    conn.commit()
+
+
+class TestTraceRouteSmoke:
+    """Verify query_trace output can be passed directly to the Jinja template."""
+
+    def test_trace_tree_template_renders_from_query_trace(self, env):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        init_db(conn)
+        _seed_web(conn)
+        result = query_trace(conn, _WEB_SID)
+        assert result is not None
+        tmpl = env.get_template("pages/trace_tree.html")
+        out = tmpl.render(trace=result)
+        assert "waterfall" in out
+        assert "icicle" in out
+
+    def test_trace_returns_none_for_missing(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        init_db(conn)
+        assert query_trace(conn, "no-such-id") is None


### PR DESCRIPTION
Closes #154

## What

`GET /trace/{trace_id}` returned HTTP 500 with `UndefinedError: 'dict object' has no attribute 'duration_ms'` because `query_trace` returned a dict missing the `duration_ms` and `tree` keys expected by `waterfall.html`.

## Changes

**`burnmap/api/trace.py`**
- `query_trace` now returns `duration_ms = max(0, ended_at - started_at)`
- `query_trace` now returns `tree` — a session-level root node with `id`, `label`, `kind`, `tokens`, `cost`, `started_at`, `ended_at`, `children`
- `_build_tree` now adds `label`, `tokens`, `cost`, `loop` aliases on each span node

**`tests/test_trace_api.py`**
- Adds `test_duration_ms_present`, `test_tree_present_with_started_at_and_children`
- Adds `TestTraceRouteSmoke` — renders full `pages/trace_tree.html` with real `query_trace` output, asserts no Jinja error

## Verification

456 passed in 16.34s

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>