### PR TITLE
fix: register max Jinja2 filter to fix /trace 500 errors

### DIFF
--- a/burnmap/api/web.py
+++ b/burnmap/api/web.py
@@ -26,11 +26,17 @@ def _format_cost(value: float) -> str:
     return f"${value:.4f}"
 
 
+def _filter_max(value: float, floor: float) -> float:
+    """Jinja2 filter: {{ value | max(floor) }} — clamp value to a minimum."""
+    return max(value, floor)
+
+
 if _FASTAPI:
     router = APIRouter()
     templates = Jinja2Templates(directory=str(_templates_dir))
     templates.env.filters["format_tok"] = _format_tok
     templates.env.filters["format_cost"] = _format_cost
+    templates.env.filters["max"] = _filter_max
 
     def _html(request: Request, template: str, **ctx: object) -> HTMLResponse:
         return templates.TemplateResponse(request, template, ctx)


### PR DESCRIPTION
Closes #156

Registers the built-in `max` filter for Jinja2 templates in `burnmap/api/web.py`.

## Issue
`/trace` and `/trace/{id}` return HTTP 500 because `waterfall.html` uses `| max(0.5)` which is unregistered in the production templates env.

## Fix
Added `_filter_max(value, floor)` helper and registered it as `templates.env.filters["max"]`.

Tests: 456 passed.