### PR TITLE
fix: token-gate enforced for non-localhost when no token file exists

### DIFF
--- a/burnmap/auth.py
+++ b/burnmap/auth.py
@@ -43,13 +43,16 @@ try:
         """Enforce bearer token auth for non-localhost requests."""
 
         async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+            if request.url.path == "/health":
+                return await call_next(request)
+
             host = request.headers.get("host", "localhost")
             if is_local_request(host):
                 return await call_next(request)
 
             token = load_token()
             if token is None:
-                return await call_next(request)  # auth disabled if no token configured
+                token = generate_token()
 
             auth_header = request.headers.get("authorization", "")
             if auth_header == f"Bearer {token}":

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -99,12 +99,14 @@ try:
             resp = client.get("/ping")
             assert resp.status_code == 401
 
-        def test_no_token_configured_passes_all(self, tmp_path, monkeypatch):
-            monkeypatch.setattr("burnmap.auth._TOKEN_FILE", tmp_path / "nonexistent")
+        def test_no_token_configured_returns_401_and_generates_token(self, tmp_path, monkeypatch):
+            token_file = tmp_path / "nonexistent"
+            monkeypatch.setattr("burnmap.auth._TOKEN_FILE", token_file)
             app = _make_app()
             client = TestClient(app, headers={"host": "remoteserver.example.com"}, raise_server_exceptions=False)
             resp = client.get("/ping")
-            assert resp.status_code == 200
+            assert resp.status_code == 401
+            assert token_file.exists()  # token was auto-generated
 
 except ImportError:
     pass  # FastAPI not installed in test env


### PR DESCRIPTION
## Summary

Fixes the silent auth bypass when `TokenAuthMiddleware` encounters a non-localhost request but no token file exists. Previously the middleware called `call_next()` unauthenticated; now it auto-generates a token and returns 401 (client must retry with the generated token).

Also exempts `/health` from auth to preserve liveness probe behaviour.

## Changes

- `burnmap/auth.py`: replace pass-through with `generate_token()` when `load_token()` is None; exempt `/health` path
- `tests/test_auth.py`: update test to assert 401 and verify token file creation

Closes #157

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>