### PR TITLE
docs(prd): drop Budget scope (Quotas + Live alerts) from PRD

### DIFF
--- a/docs-t01-burnmap/01-prd/02-scope.md
+++ b/docs-t01-burnmap/01-prd/02-scope.md
@@ -10,7 +10,6 @@
 - **Attribution labels** — `exact` / `apportioned` / `inherited` as colored badges (green / amber / gray) on each span.
 - **Content-mode privacy** — two modes (`preview` default, `full` opt-in). SHA-256 fingerprint always stored. One-command wipe drops snippets; fingerprints and aggregates are preserved.
 - **Cost estimation** — effective-dated LiteLLM pricing. Subscription runs labeled synthetic, API runs labeled real.
-- **Quota panels** — Claude 5-hour block + weekly progress bars. Pro / Max5 / Max20 / Custom. P90 auto-detect.
 - **Live tailer** — watchdog + SSE, sub-second refresh.
 - **Local-only storage** — SQLite WAL at `~/.t01-burnmap/usage.db`.
 - **One-command install** — `pipx install t01-burnmap`.

--- a/docs-t01-burnmap/01-prd/04-usage-scenarios.md
+++ b/docs-t01-burnmap/01-prd/04-usage-scenarios.md
@@ -1,12 +1,10 @@
 # 4. Usage scenarios
 
-Nine scenarios driving the v1 feature set.
+Eight scenarios driving the v1 feature set.
 
 - **Daily headline check.** Open dashboard. Top row: tokens today, cost today, cost-this-block, cost-this-week, cache-hit rate. No drill-down needed.
 
 - **Post-hoc budget-spike analysis.** A prompt cost more than usual. Prompts > sort by cost > drill into detail > histogram shows one 12x outlier > tree shows subagent Bash loop.
-
-- **Live stuck-loop interrupt.** Stuck-loop alert appears ("Bash retry #18 — $0.31"). Click into live trace, confirm loop, interrupt agent. Requires precision-mode hooks.
 
 - **Cost data export.** Export CSV of sessions over a date range. Subscription sessions labeled separately (synthetic estimates).
 

--- a/docs-t01-burnmap/01-prd/05-requirements.md
+++ b/docs-t01-burnmap/01-prd/05-requirements.md
@@ -17,7 +17,6 @@
 | **Prompts** | Fingerprinting, aggregates table, list page | P0 |
 | **Prompts** | Detail: runs list, histogram, outlier flags | P0 |
 | **Tasks** | Slash commands, skills, subagent calls — same shape as prompts | P1 |
-| **Quotas** | 5-hour block + weekly panels with ETA and burn rate | P0 |
 | **Privacy** | Two content modes (`preview`: first 5 words + fingerprint, `full`: complete text + fingerprint) with switch and wipe | P0 |
 | **Privacy** | No prompt text in export unless `--include-content` | P0 |
 | **Auth** | Token gate when HOST != localhost | P0 |

--- a/docs-t01-burnmap/01-prd/06-architecture.md
+++ b/docs-t01-burnmap/01-prd/06-architecture.md
@@ -34,7 +34,6 @@
         │  Tree · Tools · Sessions         │
         │  Outliers · Export               │
         │  Settings (+ Provider sub-pages) │
-        │  Quotas · Live alerts            │
         └──────────────────────────────────┘
 ```
 

--- a/docs-t01-burnmap/01-prd/07-phases.md
+++ b/docs-t01-burnmap/01-prd/07-phases.md
@@ -10,7 +10,6 @@ Sequential phases. Each ends with a shippable milestone.
 | **P2.5** | Span schema + ingest | 10–14 | `spans` / `trace_aggregates` / `tool_aggregates` tables |
 | **P2.75** | Tree reconstruction + subagent handling | 8–12 | parentUuid walker, sidechain merge, apportionment rules |
 | **P2.9** | Precision mode (Claude hooks) | 8–12 | Hook installer, Unix socket receiver, `span_events` merge |
-| **P3** | Quota engine + Claude panels | 6–10 | 5h / weekly rolling windows, P90 detection, UI |
 | **P4** | Prompts page + drill-down | 8–12 | List, filters, detail, histogram, outlier flags |
 | **P4.5** | Tree views: icicle + indented | 10–16 | Two views over one data source, loop-collapse rule |
 | **P5** | Tasks page + slash / skill extraction | 6–10 | Same shape as prompts, over `agent_tasks` |


### PR DESCRIPTION
Closes #171

Removes Budget section (Quotas, Live alerts) from all PRD files: 02-scope.md, 04-usage-scenarios.md, 05-requirements.md, 06-architecture.md, 07-phases.md.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>