### PR TITLE
feat(tools): add pagination to Tools page

### DIFF
--- a/burnmap/api/tools.py
+++ b/burnmap/api/tools.py
@@ -27,11 +27,12 @@ if _FASTAPI:
     @router.get("/api/tools")
     def list_tools(
         agent: str | None = Query(None, description="Filter by agent name"),
-        limit: int = Query(100, ge=1, le=1000),
+        limit: int = Query(50, ge=1, le=1000),
+        offset: int = Query(0, ge=0),
         db: sqlite3.Connection = Depends(_db),
     ) -> JSONResponse:
-        rows = query_tools(db, agent=agent, limit=limit)
-        return JSONResponse({"tools": rows})
+        rows, total = query_tools(db, agent=agent, limit=limit, offset=offset)
+        return JSONResponse({"tools": rows, "total": total, "limit": limit, "offset": offset})
 else:
     router = None  # type: ignore[assignment]
 
@@ -40,15 +41,28 @@ def query_tools(
     conn: sqlite3.Connection,
     *,
     agent: str | None = None,
-    limit: int = 100,
-) -> list[dict[str, Any]]:
-    """Return per-tool aggregate rows (kind='tool'), ordered by total_cost_usd desc."""
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return per-tool aggregate rows (kind='tool'), ordered by total_cost_usd desc.
+
+    Returns (rows, total) where total is the count of distinct tool names.
+    Default page size is 50.
+    """
     params: list[Any] = []
     agent_clause = ""
     if agent:
         agent_clause = "AND agent = ?"
         params.append(agent)
-    params.append(limit)
+
+    count_params = list(params)
+    total_row = conn.execute(
+        f"SELECT COUNT(DISTINCT name) AS n FROM spans WHERE kind = 'tool' {agent_clause}",
+        count_params,
+    ).fetchone()
+    total = total_row["n"] if total_row else 0
+
+    params.extend([limit, offset])
     cur = conn.execute(
         f"""
         SELECT
@@ -65,13 +79,17 @@ def query_tools(
         WHERE kind = 'tool' {agent_clause}
         GROUP BY name
         ORDER BY total_cost_usd DESC
-        LIMIT ?
+        LIMIT ? OFFSET ?
         """,
         params,
     )
     rows = [dict(r) for r in cur.fetchall()]
-    # Compute share of total cost
-    total = sum(r["total_cost_usd"] or 0 for r in rows)
+    # cost_share relative to the full dataset (not just this page)
+    all_cost_row = conn.execute(
+        f"SELECT SUM(cost_usd) AS s FROM spans WHERE kind = 'tool' {agent_clause}",
+        count_params,
+    ).fetchone()
+    grand_total = (all_cost_row["s"] or 0.0) if all_cost_row else 0.0
     for r in rows:
-        r["cost_share"] = round((r["total_cost_usd"] or 0) / total, 4) if total else 0.0
-    return rows
+        r["cost_share"] = round((r["total_cost_usd"] or 0) / grand_total, 4) if grand_total else 0.0
+    return rows, total

--- a/burnmap/templates/pages/tools.html
+++ b/burnmap/templates/pages/tools.html
@@ -8,7 +8,7 @@
 
   <div class="page-header">
     <h1 class="page-title">Tools</h1>
-    <span class="meta" style="font-size:12px;color:var(--ink-3)">aggregate across all traces</span>
+    <span class="meta" style="font-size:12px;color:var(--ink-3)" x-text="total + ' tools'"></span>
   </div>
 
   <template x-if="loading">
@@ -55,29 +55,56 @@
     </div>
   </template>
 
+  <template x-if="!loading && totalPages > 1">
+    <div class="pager">
+      <button class="pager-btn" :disabled="page <= 1" @click="goPage(page - 1)">&#8592; Prev</button>
+      <span class="pager-info" x-text="'Page ' + page + ' of ' + totalPages"></span>
+      <button class="pager-btn" :disabled="page >= totalPages" @click="goPage(page + 1)">Next &#8594;</button>
+    </div>
+  </template>
+
 </div>
 
 <style>
 .page-header { display:flex; align-items:center; gap:12px; margin-bottom:20px; }
 .page-title  { font-size:20px; font-weight:600; }
 .loading-row { padding:40px; text-align:center; color:var(--ink-3,#888); font-size:14px; }
+.pager { display:flex; align-items:center; gap:12px; margin-top:16px; justify-content:center; font-size:13px; }
+.pager-btn { padding:4px 12px; border:1px solid var(--rule-soft,#ddd); border-radius:4px; background:none; cursor:pointer; }
+.pager-btn:disabled { opacity:0.4; cursor:default; }
+.pager-info { color:var(--ink-3,#888); }
 </style>
 
 <script>
+const TOOLS_PAGE_SIZE = 50;
+
 function toolsPage() {
   return {
     rows: [],
+    total: 0,
+    page: 1,
     loading: false,
+
+    get totalPages() {
+      return Math.max(1, Math.ceil(this.total / TOOLS_PAGE_SIZE));
+    },
 
     async load() {
       this.loading = true;
+      const offset = (this.page - 1) * TOOLS_PAGE_SIZE;
       try {
-        const r = await fetch('/api/tools?limit=200');
+        const r = await fetch(`/api/tools?limit=${TOOLS_PAGE_SIZE}&offset=${offset}`);
         const d = await r.json();
         this.rows = d.tools || [];
+        this.total = d.total || 0;
       } finally {
         this.loading = false;
       }
+    },
+
+    goPage(n) {
+      this.page = n;
+      this.load();
     },
 
     fmtTok(n) {

--- a/tests/test_tools_api.py
+++ b/tests/test_tools_api.py
@@ -38,7 +38,7 @@ def _seed(conn: sqlite3.Connection) -> None:
 
 class TestQueryTools:
     def test_returns_only_tool_kind(self, db):
-        rows = query_tools(db)
+        rows, total = query_tools(db)
         assert all(True for _ in rows)  # no kind field in output — just names
         names = {r["name"] for r in rows}
         assert "/commit" not in names
@@ -46,49 +46,66 @@ class TestQueryTools:
         assert "Write" in names
 
     def test_aggregates_calls(self, db):
-        rows = query_tools(db)
+        rows, _ = query_tools(db)
         read_row = next(r for r in rows if r["name"] == "Read")
         # t1, t2 (claude_code) + t5 (codex) = 3 calls
         assert read_row["calls"] == 3
 
     def test_token_sums(self, db):
-        rows = query_tools(db)
+        rows, _ = query_tools(db)
         read_row = next(r for r in rows if r["name"] == "Read")
         assert read_row["total_input_tokens"] == 380
         assert read_row["total_output_tokens"] == 0
 
     def test_cost_sum(self, db):
-        rows = query_tools(db)
+        rows, _ = query_tools(db)
         read_row = next(r for r in rows if r["name"] == "Read")
         assert abs(read_row["total_cost_usd"] - 0.004) < 1e-9
 
     def test_ordered_by_cost_desc(self, db):
-        rows = query_tools(db)
+        rows, _ = query_tools(db)
         costs = [r["total_cost_usd"] for r in rows]
         assert costs == sorted(costs, reverse=True)
 
     def test_cost_share_sums_to_one(self, db):
-        rows = query_tools(db)
+        rows, _ = query_tools(db)
         total_share = sum(r["cost_share"] for r in rows)
         assert abs(total_share - 1.0) < 0.01
 
+    def test_total_count(self, db):
+        _, total = query_tools(db)
+        assert total == 2  # Read and Write
+
+    def test_pagination(self, db):
+        rows_p1, total = query_tools(db, limit=1, offset=0)
+        rows_p2, _ = query_tools(db, limit=1, offset=1)
+        assert total == 2
+        assert len(rows_p1) == 1
+        assert len(rows_p2) == 1
+        # Pages should not overlap
+        assert rows_p1[0]["name"] != rows_p2[0]["name"]
+
     def test_limit(self, db):
-        rows = query_tools(db, limit=1)
+        rows, _ = query_tools(db, limit=1)
         assert len(rows) == 1
 
     def test_agent_filter(self, db):
-        rows = query_tools(db, agent="codex")
+        rows, total = query_tools(db, agent="codex")
+        assert total == 1
         assert len(rows) == 1
         assert rows[0]["name"] == "Read"
         assert rows[0]["calls"] == 1
 
     def test_agent_filter_no_match(self, db):
-        rows = query_tools(db, agent="unknown_agent")
+        rows, total = query_tools(db, agent="unknown_agent")
         assert rows == []
+        assert total == 0
 
     def test_empty_db(self):
         conn = sqlite3.connect(":memory:")
         conn.row_factory = sqlite3.Row
         init_db(conn)
-        assert query_tools(conn) == []
+        rows, total = query_tools(conn)
+        assert rows == []
+        assert total == 0
         conn.close()


### PR DESCRIPTION
Closes #168

- query_tools() now returns (rows, total) tuple with offset support
- Default page size 50 (documented here)
- GET /api/tools?limit=N&offset=M returns {tools, total, limit, offset}
- Frontend pager: prev/next + page X of Y

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>