### PR TITLE
feat(tools): tool detail page - drill into a single tool

### DIFF
--- a/burnmap/api/tools.py
+++ b/burnmap/api/tools.py
@@ -5,7 +5,7 @@ import sqlite3
 from typing import Any
 
 try:
-    from fastapi import APIRouter, Depends, Query
+    from fastapi import APIRouter, Depends, HTTPException, Query
     from fastapi.responses import JSONResponse
     _FASTAPI = True
 except ImportError:
@@ -33,6 +33,18 @@ if _FASTAPI:
     ) -> JSONResponse:
         rows, total = query_tools(db, agent=agent, limit=limit, offset=offset)
         return JSONResponse({"tools": rows, "total": total, "limit": limit, "offset": offset})
+
+    @router.get("/api/tools/{tool_name}")
+    def tool_detail(
+        tool_name: str,
+        limit: int = Query(100, ge=1, le=1000),
+        db: sqlite3.Connection = Depends(_db),
+    ) -> JSONResponse:
+        agg = query_tool_aggregate(db, tool_name)
+        if agg is None:
+            raise HTTPException(status_code=404, detail="Tool not found")
+        calls = query_tool_calls(db, tool_name, limit=limit)
+        return JSONResponse({"aggregate": agg, "calls": calls})
 else:
     router = None  # type: ignore[assignment]
 
@@ -93,3 +105,66 @@ def query_tools(
     for r in rows:
         r["cost_share"] = round((r["total_cost_usd"] or 0) / grand_total, 4) if grand_total else 0.0
     return rows, total
+
+
+def query_tool_aggregate(
+    conn: sqlite3.Connection,
+    tool_name: str,
+) -> dict[str, Any] | None:
+    """Return aggregate stats for a single tool name. Returns None if not found."""
+    # Grand total cost for cost_share
+    grand = conn.execute(
+        "SELECT SUM(cost_usd) AS s FROM spans WHERE kind = 'tool'"
+    ).fetchone()
+    grand_total = (grand["s"] or 0.0) if grand else 0.0
+
+    cur = conn.execute(
+        """
+        SELECT
+            name,
+            COUNT(*)                                        AS calls,
+            SUM(input_tokens)                               AS total_input_tokens,
+            SUM(output_tokens)                              AS total_output_tokens,
+            CAST(
+              (SUM(input_tokens) + SUM(output_tokens)) AS REAL
+            ) / COUNT(*)                                    AS avg_tokens_per_call,
+            SUM(cost_usd)                                   AS total_cost_usd
+        FROM spans
+        WHERE kind = 'tool' AND name = ?
+        GROUP BY name
+        """,
+        [tool_name],
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    result = dict(row)
+    result["cost_share"] = round((result["total_cost_usd"] or 0) / grand_total, 4) if grand_total else 0.0
+    return result
+
+
+def query_tool_calls(
+    conn: sqlite3.Connection,
+    tool_name: str,
+    *,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Return recent individual calls for a specific tool, newest first."""
+    cur = conn.execute(
+        """
+        SELECT
+            id          AS span_id,
+            session_id,
+            agent,
+            input_tokens,
+            output_tokens,
+            cost_usd,
+            started_at
+        FROM spans
+        WHERE kind = 'tool' AND name = ?
+        ORDER BY started_at DESC
+        LIMIT ?
+        """,
+        [tool_name, limit],
+    )
+    return [dict(r) for r in cur.fetchall()]

--- a/burnmap/api/web.py
+++ b/burnmap/api/web.py
@@ -112,6 +112,10 @@ if _FASTAPI:
     def tools(request: Request) -> HTMLResponse:
         return _html(request, "pages/tools.html")
 
+    @router.get("/tools/{tool_name}", response_class=HTMLResponse)
+    def tool_detail(request: Request, tool_name: str) -> HTMLResponse:
+        return _html(request, "pages/tool_detail.html", tool_name=tool_name)
+
     @router.get("/sessions", response_class=HTMLResponse)
     def sessions(request: Request) -> HTMLResponse:
         return _html(request, "pages/sessions.html")

--- a/burnmap/templates/pages/tool_detail.html
+++ b/burnmap/templates/pages/tool_detail.html
@@ -1,0 +1,146 @@
+{# tool_detail.html — per-tool detail: aggregates + recent calls #}
+{% extends "base.html" %}
+
+{% block title %}{{ tool_name }} — Tools — burnmap{% endblock %}
+
+{% block content %}
+<div x-data="toolDetailPage({{ tool_name | tojson }})" x-init="load()">
+
+  <div class="page-header">
+    <a href="/tools" class="back-link">&#8592; Tools</a>
+    <h1 class="page-title mono" x-text="toolName"></h1>
+  </div>
+
+  <template x-if="loading">
+    <div class="loading-row">Loading…</div>
+  </template>
+
+  <template x-if="!loading && notFound">
+    <div class="loading-row">Tool not found.</div>
+  </template>
+
+  <template x-if="!loading && !notFound && agg">
+    <div>
+      <!-- Aggregate stats -->
+      <div class="stats-row">
+        <div class="stat-card">
+          <div class="stat-label">Total calls</div>
+          <div class="stat-value" x-text="(agg.calls || 0).toLocaleString()"></div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Total tokens</div>
+          <div class="stat-value" x-text="fmtTok((agg.total_input_tokens || 0) + (agg.total_output_tokens || 0))"></div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Total cost</div>
+          <div class="stat-value mono" x-text="'$' + (agg.total_cost_usd || 0).toFixed(4)"></div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Avg tokens / call</div>
+          <div class="stat-value" x-text="Math.round(agg.avg_tokens_per_call || 0).toLocaleString()"></div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Cost share</div>
+          <div class="stat-value" x-text="((agg.cost_share || 0) * 100).toFixed(1) + '%'"></div>
+        </div>
+      </div>
+
+      <!-- Recent calls table -->
+      <div class="section-header">Recent calls <span class="muted" style="font-size:12px">(newest first, limit 100)</span></div>
+
+      <template x-if="calls.length === 0">
+        <div class="loading-row">No calls recorded.</div>
+      </template>
+
+      <template x-if="calls.length > 0">
+        <div class="card" style="overflow-x:auto">
+          <table class="t">
+            <thead>
+              <tr>
+                <th>Session</th>
+                <th>Agent</th>
+                <th>Started</th>
+                <th class="right">Input tok</th>
+                <th class="right">Output tok</th>
+                <th class="right">Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template x-for="c in calls" :key="c.span_id">
+                <tr>
+                  <td>
+                    <a class="mono session-link" :href="'/trace/' + encodeURIComponent(c.session_id)"
+                       x-text="c.session_id.slice(0, 16) + '…'"></a>
+                  </td>
+                  <td><span class="agent-badge" x-text="c.agent"></span></td>
+                  <td class="mono muted" style="font-size:11px" x-text="fmtTime(c.started_at)"></td>
+                  <td class="num right" x-text="(c.input_tokens || 0).toLocaleString()"></td>
+                  <td class="num right" x-text="(c.output_tokens || 0).toLocaleString()"></td>
+                  <td class="num right mono" x-text="'$' + (c.cost_usd || 0).toFixed(4)"></td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+      </template>
+    </div>
+  </template>
+
+</div>
+
+<style>
+.page-header  { display:flex; align-items:center; gap:12px; margin-bottom:20px; }
+.page-title   { font-size:20px; font-weight:600; word-break:break-all; }
+.back-link    { font-size:13px; color:var(--ink-3,#888); text-decoration:none; white-space:nowrap; }
+.back-link:hover { color:var(--accent,#0070f3); }
+.loading-row  { padding:40px; text-align:center; color:var(--ink-3,#888); font-size:14px; }
+.stats-row    { display:flex; gap:12px; flex-wrap:wrap; margin-bottom:24px; }
+.stat-card    { flex:1; min-width:120px; background:var(--paper-2,#f7f7f7);
+                border:1px solid var(--rule-soft,#e0e0e0); border-radius:6px; padding:12px 16px; }
+.stat-label   { font-size:11px; color:var(--ink-3,#888); margin-bottom:4px; }
+.stat-value   { font-size:18px; font-weight:600; }
+.section-header { font-size:13px; font-weight:600; margin-bottom:10px; color:var(--ink-2,#444); }
+.session-link { color:var(--accent,#0070f3); text-decoration:none; }
+.session-link:hover { text-decoration:underline; }
+</style>
+
+<script>
+function toolDetailPage(toolName) {
+  return {
+    toolName,
+    agg: null,
+    calls: [],
+    loading: false,
+    notFound: false,
+
+    async load() {
+      this.loading = true;
+      try {
+        const r = await fetch('/api/tools/' + encodeURIComponent(this.toolName) + '?limit=100');
+        if (r.status === 404) { this.notFound = true; return; }
+        const d = await r.json();
+        this.agg   = d.aggregate || null;
+        this.calls = d.calls || [];
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    fmtTok(n) {
+      if (!n) return '0';
+      if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+      if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+      return String(n);
+    },
+
+    fmtTime(ms) {
+      if (!ms) return '—';
+      return new Date(ms).toLocaleString(undefined, {
+        month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      });
+    },
+  };
+}
+</script>
+{% endblock %}

--- a/burnmap/templates/pages/tools.html
+++ b/burnmap/templates/pages/tools.html
@@ -35,7 +35,7 @@
         <tbody>
           <template x-for="t in rows" :key="t.name">
             <tr>
-              <td><b class="mono" x-text="t.name"></b></td>
+              <td><a class="mono tool-link" :href="'/tools/' + encodeURIComponent(t.name)" x-text="t.name"></a></td>
               <td class="num right" x-text="t.calls.toLocaleString()"></td>
               <td class="num right" x-text="fmtTok(t.total_input_tokens + t.total_output_tokens)"></td>
               <td class="num right" x-text="Math.round(t.avg_tokens_per_call).toLocaleString()"></td>
@@ -73,6 +73,8 @@
 .pager-btn { padding:4px 12px; border:1px solid var(--rule-soft,#ddd); border-radius:4px; background:none; cursor:pointer; }
 .pager-btn:disabled { opacity:0.4; cursor:default; }
 .pager-info { color:var(--ink-3,#888); }
+.tool-link { color:var(--accent,#0070f3); text-decoration:none; }
+.tool-link:hover { text-decoration:underline; }
 </style>
 
 <script>

--- a/tests/test_tool_detail_api.py
+++ b/tests/test_tool_detail_api.py
@@ -1,0 +1,83 @@
+"""Tests for burnmap.api.tools — query_tool_aggregate and query_tool_calls."""
+import sqlite3
+
+import pytest
+
+from burnmap.api.tools import query_tool_aggregate, query_tool_calls
+from burnmap.db.schema import init_db
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    _seed(conn)
+    yield conn
+    conn.close()
+
+
+def _seed(conn: sqlite3.Connection) -> None:
+    rows = [
+        # id, session_id, agent, kind, name, input_tokens, output_tokens, cost_usd, started_at
+        ("t1", "sess-a", "claude_code", "tool", "Read", 100, 0, 0.001, 1_700_000_000_000),
+        ("t2", "sess-a", "claude_code", "tool", "Read", 200, 0, 0.002, 1_700_000_001_000),
+        ("t3", "sess-b", "codex",       "tool", "Write", 50, 0, 0.005, 1_700_000_002_000),
+    ]
+    conn.executemany(
+        "INSERT INTO spans (id, session_id, agent, kind, name, input_tokens, output_tokens, cost_usd, started_at)"
+        " VALUES (?,?,?,?,?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+
+
+class TestQueryToolAggregate:
+    def test_returns_aggregate_for_known_tool(self, db):
+        agg = query_tool_aggregate(db, "Read")
+        assert agg is not None
+        assert agg["name"] == "Read"
+        assert agg["calls"] == 2
+        assert agg["total_input_tokens"] == 300
+        assert abs(agg["total_cost_usd"] - 0.003) < 1e-9
+
+    def test_returns_none_for_unknown_tool(self, db):
+        assert query_tool_aggregate(db, "NonExistent") is None
+
+    def test_cost_share_is_fraction(self, db):
+        agg = query_tool_aggregate(db, "Read")
+        assert agg is not None
+        assert 0.0 <= agg["cost_share"] <= 1.0
+
+    def test_cost_share_correct(self, db):
+        # Read costs 0.003, Write 0.005 — total 0.008
+        agg = query_tool_aggregate(db, "Read")
+        assert agg is not None
+        expected = round(0.003 / 0.008, 4)
+        assert abs(agg["cost_share"] - expected) < 0.001
+
+
+class TestQueryToolCalls:
+    def test_returns_calls_for_known_tool(self, db):
+        calls = query_tool_calls(db, "Read")
+        assert len(calls) == 2
+
+    def test_returns_empty_for_unknown_tool(self, db):
+        calls = query_tool_calls(db, "NonExistent")
+        assert calls == []
+
+    def test_ordered_newest_first(self, db):
+        calls = query_tool_calls(db, "Read")
+        timestamps = [c["started_at"] for c in calls]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    def test_limit(self, db):
+        calls = query_tool_calls(db, "Read", limit=1)
+        assert len(calls) == 1
+
+    def test_has_required_fields(self, db):
+        calls = query_tool_calls(db, "Read")
+        assert len(calls) > 0
+        row = calls[0]
+        for field in ("span_id", "session_id", "agent", "input_tokens", "output_tokens", "cost_usd", "started_at"):
+            assert field in row


### PR DESCRIPTION
Closes #169

- GET /api/tools/{tool_name} returns aggregate + recent calls (404 for unknown)
- GET /tools/{tool_name} renders pages/tool_detail.html
- Tool names in tools.html now link to detail page
- URL-safe via encodeURIComponent on frontend
- 9 new tests in test_tool_detail_api.py

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>