### PR TITLE
feat(tools): add filters to Tools page (search + agent)

### DIFF
--- a/burnmap/api/tools.py
+++ b/burnmap/api/tools.py
@@ -27,11 +27,12 @@ if _FASTAPI:
     @router.get("/api/tools")
     def list_tools(
         agent: str | None = Query(None, description="Filter by agent name"),
+        q: str | None = Query(None, description="Filter by tool name (LIKE)"),
         limit: int = Query(50, ge=1, le=1000),
         offset: int = Query(0, ge=0),
         db: sqlite3.Connection = Depends(_db),
     ) -> JSONResponse:
-        rows, total = query_tools(db, agent=agent, limit=limit, offset=offset)
+        rows, total = query_tools(db, agent=agent, q=q, limit=limit, offset=offset)
         return JSONResponse({"tools": rows, "total": total, "limit": limit, "offset": offset})
 
     @router.get("/api/tools/{tool_name}")
@@ -53,24 +54,28 @@ def query_tools(
     conn: sqlite3.Connection,
     *,
     agent: str | None = None,
+    q: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> tuple[list[dict[str, Any]], int]:
     """Return per-tool aggregate rows (kind='tool'), ordered by total_cost_usd desc.
 
-    Returns (rows, total) where total is the count of distinct tool names.
-    Default page size is 50.
+    Returns (rows, total) where total is the count of distinct tool names matching
+    the filters (unaffected by limit/offset).
     """
     params: list[Any] = []
-    agent_clause = ""
+    extra_clauses = ""
     if agent:
-        agent_clause = "AND agent = ?"
+        extra_clauses += " AND agent = ?"
         params.append(agent)
+    if q:
+        extra_clauses += " AND name LIKE ?"
+        params.append(f"%{q}%")
 
-    count_params = list(params)
+    filter_params = list(params)
     total_row = conn.execute(
-        f"SELECT COUNT(DISTINCT name) AS n FROM spans WHERE kind = 'tool' {agent_clause}",
-        count_params,
+        f"SELECT COUNT(DISTINCT name) AS n FROM spans WHERE kind = 'tool' {extra_clauses}",
+        filter_params,
     ).fetchone()
     total = total_row["n"] if total_row else 0
 
@@ -88,7 +93,7 @@ def query_tools(
             SUM(cost_usd)                                   AS total_cost_usd,
             MAX(started_at)                                 AS last_seen_ms
         FROM spans
-        WHERE kind = 'tool' {agent_clause}
+        WHERE kind = 'tool' {extra_clauses}
         GROUP BY name
         ORDER BY total_cost_usd DESC
         LIMIT ? OFFSET ?
@@ -98,8 +103,8 @@ def query_tools(
     rows = [dict(r) for r in cur.fetchall()]
     # cost_share relative to the full dataset (not just this page)
     all_cost_row = conn.execute(
-        f"SELECT SUM(cost_usd) AS s FROM spans WHERE kind = 'tool' {agent_clause}",
-        count_params,
+        f"SELECT SUM(cost_usd) AS s FROM spans WHERE kind = 'tool' {extra_clauses}",
+        filter_params,
     ).fetchone()
     grand_total = (all_cost_row["s"] or 0.0) if all_cost_row else 0.0
     for r in rows:

--- a/burnmap/templates/pages/tools.html
+++ b/burnmap/templates/pages/tools.html
@@ -11,6 +11,24 @@
     <span class="meta" style="font-size:12px;color:var(--ink-3)" x-text="total + ' tools'"></span>
   </div>
 
+  <!-- Search + filter controls -->
+  <div class="row" style="margin-bottom:14px;gap:8px;flex-wrap:wrap">
+    <input class="search-input"
+           type="search"
+           placeholder="Search tool name…"
+           x-model="search"
+           @input.debounce.250ms="load()"/>
+    <select class="sort-select" x-model="agentFilter" @change="load()">
+      <option value="">Agent: any</option>
+      <option value="claude_code">claude_code</option>
+      <option value="codex">codex</option>
+      <option value="aider">aider</option>
+    </select>
+    <span class="spacer"></span>
+    <span class="mono muted" style="font-size:11px;align-self:center"
+          x-text="rows.length + ' tools'"></span>
+  </div>
+
   <template x-if="loading">
     <div class="loading-row">Loading…</div>
   </template>
@@ -66,15 +84,17 @@
 </div>
 
 <style>
-.page-header { display:flex; align-items:center; gap:12px; margin-bottom:20px; }
-.page-title  { font-size:20px; font-weight:600; }
-.loading-row { padding:40px; text-align:center; color:var(--ink-3,#888); font-size:14px; }
-.pager { display:flex; align-items:center; gap:12px; margin-top:16px; justify-content:center; font-size:13px; }
-.pager-btn { padding:4px 12px; border:1px solid var(--rule-soft,#ddd); border-radius:4px; background:none; cursor:pointer; }
+.page-header  { display:flex; align-items:center; gap:12px; margin-bottom:20px; }
+.page-title   { font-size:20px; font-weight:600; }
+.loading-row  { padding:40px; text-align:center; color:var(--ink-3,#888); font-size:14px; }
+.pager        { display:flex; align-items:center; gap:12px; margin-top:16px; justify-content:center; font-size:13px; }
+.pager-btn    { padding:4px 12px; border:1px solid var(--rule-soft,#ddd); border-radius:4px; background:none; cursor:pointer; }
 .pager-btn:disabled { opacity:0.4; cursor:default; }
-.pager-info { color:var(--ink-3,#888); }
-.tool-link { color:var(--accent,#0070f3); text-decoration:none; }
+.pager-info   { color:var(--ink-3,#888); }
+.tool-link    { color:var(--accent,#0070f3); text-decoration:none; }
 .tool-link:hover { text-decoration:underline; }
+.search-input { font-size:13px; padding:5px 10px; border:1px solid var(--rule-soft,#ddd); border-radius:4px; min-width:260px; }
+.sort-select  { font-size:13px; padding:4px 8px; border:1px solid var(--rule-soft,#ddd); border-radius:4px; }
 </style>
 
 <script>
@@ -86,6 +106,8 @@ function toolsPage() {
     total: 0,
     page: 1,
     loading: false,
+    search: '',
+    agentFilter: '',
 
     get totalPages() {
       return Math.max(1, Math.ceil(this.total / TOOLS_PAGE_SIZE));
@@ -95,7 +117,10 @@ function toolsPage() {
       this.loading = true;
       const offset = (this.page - 1) * TOOLS_PAGE_SIZE;
       try {
-        const r = await fetch(`/api/tools?limit=${TOOLS_PAGE_SIZE}&offset=${offset}`);
+        let url = `/api/tools?limit=${TOOLS_PAGE_SIZE}&offset=${offset}`;
+        if (this.search) url += '&q=' + encodeURIComponent(this.search);
+        if (this.agentFilter) url += '&agent=' + encodeURIComponent(this.agentFilter);
+        const r = await fetch(url);
         const d = await r.json();
         this.rows = d.tools || [];
         this.total = d.total || 0;

--- a/tests/test_tools_api.py
+++ b/tests/test_tools_api.py
@@ -101,6 +101,32 @@ class TestQueryTools:
         assert rows == []
         assert total == 0
 
+    def test_q_filter_exact(self, db):
+        rows = query_tools(db, q="Write")
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Write"
+
+    def test_q_filter_partial(self, db):
+        rows = query_tools(db, q="rea")
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Read"
+
+    def test_q_filter_no_match(self, db):
+        rows = query_tools(db, q="nonexistent_tool_xyz")
+        assert rows == []
+
+    def test_q_and_agent_compose(self, db):
+        # Read exists for both agents, but codex only
+        rows = query_tools(db, q="Read", agent="codex")
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Read"
+        assert rows[0]["calls"] == 1  # only codex call
+
+    def test_empty_q_returns_all(self, db):
+        rows_no_q = query_tools(db)
+        rows_empty_q = query_tools(db, q="")
+        assert len(rows_no_q) == len(rows_empty_q)
+
     def test_empty_db(self):
         conn = sqlite3.connect(":memory:")
         conn.row_factory = sqlite3.Row

--- a/tests/test_tools_api.py
+++ b/tests/test_tools_api.py
@@ -102,30 +102,31 @@ class TestQueryTools:
         assert total == 0
 
     def test_q_filter_exact(self, db):
-        rows = query_tools(db, q="Write")
+        rows, _ = query_tools(db, q="Write")
         assert len(rows) == 1
         assert rows[0]["name"] == "Write"
 
     def test_q_filter_partial(self, db):
-        rows = query_tools(db, q="rea")
+        rows, _ = query_tools(db, q="rea")
         assert len(rows) == 1
         assert rows[0]["name"] == "Read"
 
     def test_q_filter_no_match(self, db):
-        rows = query_tools(db, q="nonexistent_tool_xyz")
+        rows, _ = query_tools(db, q="nonexistent_tool_xyz")
         assert rows == []
 
     def test_q_and_agent_compose(self, db):
         # Read exists for both agents, but codex only
-        rows = query_tools(db, q="Read", agent="codex")
+        rows, _ = query_tools(db, q="Read", agent="codex")
         assert len(rows) == 1
         assert rows[0]["name"] == "Read"
         assert rows[0]["calls"] == 1  # only codex call
 
     def test_empty_q_returns_all(self, db):
-        rows_no_q = query_tools(db)
-        rows_empty_q = query_tools(db, q="")
+        rows_no_q, total_no_q = query_tools(db)
+        rows_empty_q, total_empty_q = query_tools(db, q="")
         assert len(rows_no_q) == len(rows_empty_q)
+        assert total_no_q == total_empty_q
 
     def test_empty_db(self):
         conn = sqlite3.connect(":memory:")


### PR DESCRIPTION
Closes #167

Adds `q` (LIKE) filter to `GET /api/tools` and frontend search input + agent dropdown. Debounced 250ms. Filters compose. Tests added.