### PR TITLE
fix(trace): trace tree page renders unstyled (missing base.html extend)

### DIFF
--- a/burnmap/templates/pages/trace_tree.html
+++ b/burnmap/templates/pages/trace_tree.html
@@ -6,7 +6,12 @@
      .id, .label, .kind, .tokens, .cost, .loop, .children (list),
      .started_at (ms epoch, optional), .ended_at (ms epoch, optional)
 #}
+{% extends "base.html" %}
 {% from "components/waterfall.html" import waterfall_tab %}
+
+{% block title %}Trace — burnmap{% endblock %}
+
+{% block content %}
 
 {# ── Icicle macro ─────────────────────────────────────────────────────── #}
 {% macro icicle_row(node, depth, total_tokens) %}
@@ -191,3 +196,4 @@ function traceTreePage() {
   };
 }
 </script>
+{% endblock %}


### PR DESCRIPTION
Closes #166

Adds `{% extends "base.html" %}`, `{% block title %}`, and `{% block content %}` wrapper to trace_tree.html. All other pages/*.html already extend base. Inline styles kept inside the content block.