### PR TITLE
feat(sessions): add date range filter to Sessions page

### DIFF
--- a/burnmap/api/sessions.py
+++ b/burnmap/api/sessions.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import date, datetime, timezone
 from typing import Any
 
 try:
@@ -28,14 +29,27 @@ if _FASTAPI:
     def list_sessions(
         agent: str | None = Query(None, description="Filter by agent name"),
         search: str | None = Query(None, description="Filter by session id substring"),
+        started_from: str | None = Query(None, description="ISO date YYYY-MM-DD inclusive lower bound"),
+        started_to: str | None = Query(None, description="ISO date YYYY-MM-DD inclusive upper bound"),
         limit: int = Query(50, ge=1, le=1000),
         offset: int = Query(0, ge=0),
         db: sqlite3.Connection = Depends(_db),
     ) -> JSONResponse:
-        rows, total = query_sessions(db, agent=agent, search=search, limit=limit, offset=offset)
+        rows, total = query_sessions(
+            db, agent=agent, search=search,
+            started_from=started_from, started_to=started_to,
+            limit=limit, offset=offset,
+        )
         return JSONResponse({"sessions": rows, "total": total, "limit": limit, "offset": offset})
 else:
     router = None  # type: ignore[assignment]
+
+
+def _date_to_ms(d: str, end_of_day: bool = False) -> int:
+    """Convert YYYY-MM-DD to millisecond epoch. end_of_day=True adds 86399999ms."""
+    dt = datetime.strptime(d, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    ms = int(dt.timestamp() * 1000)
+    return ms + 86_399_999 if end_of_day else ms
 
 
 def query_sessions(
@@ -43,6 +57,8 @@ def query_sessions(
     *,
     agent: str | None = None,
     search: str | None = None,
+    started_from: str | None = None,
+    started_to: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> tuple[list[dict[str, Any]], int]:
@@ -56,6 +72,12 @@ def query_sessions(
     if search:
         where_clauses.append("s.id LIKE ?")
         params.append(f"%{search}%")
+    if started_from:
+        where_clauses.append("s.started_at >= ?")
+        params.append(_date_to_ms(started_from))
+    if started_to:
+        where_clauses.append("s.started_at <= ?")
+        params.append(_date_to_ms(started_to, end_of_day=True))
 
     where = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
 

--- a/burnmap/templates/pages/sessions.html
+++ b/burnmap/templates/pages/sessions.html
@@ -24,6 +24,8 @@
       <option value="codex">codex</option>
       <option value="aider">aider</option>
     </select>
+    <input class="date-input" type="date" x-model="dateFrom" @change="load()" title="From date"/>
+    <input class="date-input" type="date" x-model="dateTo" @change="load()" title="To date"/>
     <span class="spacer"></span>
     <span class="mono muted" style="font-size:11px;align-self:center"
           x-text="total + ' sessions'"></span>
@@ -107,6 +109,7 @@
 .chip--outlier { background:#fee2e2; color:#991b1b; }
 .session-id-link { color:var(--ink); text-decoration:none; }
 .session-id-link:hover { color:var(--accent,#0070f3); text-decoration:underline; cursor:pointer; }
+.date-input    { font-size:13px; padding:4px 8px; border:1px solid var(--rule-soft,#ddd); border-radius:4px; }
 </style>
 
 <script>
@@ -119,6 +122,8 @@ function sessionsPage() {
     loading: false,
     search: '',
     agentFilter: '',
+    dateFrom: '',
+    dateTo: '',
 
     async load() {
       this.loading = true;
@@ -127,6 +132,8 @@ function sessionsPage() {
         let url = `/api/sessions?limit=${this.limit}&offset=${offset}`;
         if (this.search) url += '&search=' + encodeURIComponent(this.search);
         if (this.agentFilter) url += '&agent=' + encodeURIComponent(this.agentFilter);
+        if (this.dateFrom) url += '&started_from=' + encodeURIComponent(this.dateFrom);
+        if (this.dateTo) url += '&started_to=' + encodeURIComponent(this.dateTo);
         const r = await fetch(url);
         const d = await r.json();
         this.rows  = d.sessions || [];

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -4,7 +4,7 @@ import uuid
 
 import pytest
 
-from burnmap.api.sessions import query_sessions
+from burnmap.api.sessions import _date_to_ms, query_sessions
 from burnmap.db.schema import init_db
 
 
@@ -134,3 +134,51 @@ class TestQuerySessions:
         assert total == 1
         assert rows[0]["span_count"] == 0
         conn.close()
+
+
+class TestDateToMs:
+    def test_known_date(self):
+        ms = _date_to_ms("2023-11-14")
+        # 2023-11-14 00:00:00 UTC in ms
+        assert ms == 1_699_920_000_000
+
+    def test_end_of_day(self):
+        ms_start = _date_to_ms("2023-11-14")
+        ms_end = _date_to_ms("2023-11-14", end_of_day=True)
+        assert ms_end == ms_start + 86_399_999
+
+
+class TestDateRangeFilter:
+    # _SID_A started_at = 1_700_000_000_000 ms = 2023-11-14 22:13:20 UTC
+    # _SID_B started_at = 1_700_000_200_000 ms = 2023-11-14 22:16:40 UTC
+
+    def test_started_from_includes_exact_date(self, db):
+        # both sessions are on 2023-11-14
+        rows, _ = query_sessions(db, started_from="2023-11-14")
+        assert len(rows) == 2
+
+    def test_started_from_excludes_earlier(self, db):
+        # future date — no sessions
+        rows, _ = query_sessions(db, started_from="2025-01-01")
+        assert rows == []
+
+    def test_started_to_includes_exact_date(self, db):
+        rows, _ = query_sessions(db, started_to="2023-11-14")
+        assert len(rows) == 2
+
+    def test_started_to_excludes_later(self, db):
+        rows, _ = query_sessions(db, started_to="2020-01-01")
+        assert rows == []
+
+    def test_date_range_window(self, db):
+        rows, _ = query_sessions(db, started_from="2023-11-14", started_to="2023-11-14")
+        assert len(rows) == 2
+
+    def test_date_range_excludes_both(self, db):
+        rows, _ = query_sessions(db, started_from="2024-01-01", started_to="2024-12-31")
+        assert rows == []
+
+    def test_date_range_composes_with_agent(self, db):
+        rows, _ = query_sessions(db, agent="codex", started_from="2023-11-14")
+        assert len(rows) == 1
+        assert rows[0]["id"] == _SID_B


### PR DESCRIPTION
Closes #164

Adds `started_from` / `started_to` (ISO date YYYY-MM-DD) params to `GET /api/sessions`. Adds two date inputs in the filter row. Composes with agent/search/pager. Tests cover boundary behavior.