### PR TITLE
feat(sessions): add pagination to Sessions page

### DIFF
--- a/burnmap/api/sessions.py
+++ b/burnmap/api/sessions.py
@@ -28,11 +28,12 @@ if _FASTAPI:
     def list_sessions(
         agent: str | None = Query(None, description="Filter by agent name"),
         search: str | None = Query(None, description="Filter by session id substring"),
-        limit: int = Query(100, ge=1, le=1000),
+        limit: int = Query(50, ge=1, le=1000),
+        offset: int = Query(0, ge=0),
         db: sqlite3.Connection = Depends(_db),
     ) -> JSONResponse:
-        rows = query_sessions(db, agent=agent, search=search, limit=limit)
-        return JSONResponse({"sessions": rows, "count": len(rows)})
+        rows, total = query_sessions(db, agent=agent, search=search, limit=limit, offset=offset)
+        return JSONResponse({"sessions": rows, "total": total, "limit": limit, "offset": offset})
 else:
     router = None  # type: ignore[assignment]
 
@@ -42,9 +43,10 @@ def query_sessions(
     *,
     agent: str | None = None,
     search: str | None = None,
-    limit: int = 100,
-) -> list[dict[str, Any]]:
-    """Return session rows with aggregate stats and outlier flag."""
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return (rows, total) with aggregate stats and outlier flag. Default page size 50."""
     where_clauses = []
     params: list[Any] = []
 
@@ -56,6 +58,11 @@ def query_sessions(
         params.append(f"%{search}%")
 
     where = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    count_row = conn.execute(
+        f"SELECT COUNT(*) AS n FROM sessions s {where}", params
+    ).fetchone()
+    total = count_row["n"] if count_row else 0
 
     cur = conn.execute(
         f"""
@@ -73,8 +80,8 @@ def query_sessions(
         {where}
         GROUP BY s.id
         ORDER BY s.started_at DESC
-        LIMIT ?
+        LIMIT ? OFFSET ?
         """,
-        (*params, limit),
+        (*params, limit, offset),
     )
-    return [dict(r) for r in cur.fetchall()]
+    return [dict(r) for r in cur.fetchall()], total

--- a/burnmap/templates/pages/sessions.html
+++ b/burnmap/templates/pages/sessions.html
@@ -26,7 +26,7 @@
     </select>
     <span class="spacer"></span>
     <span class="mono muted" style="font-size:11px;align-self:center"
-          x-text="count + ' sessions'"></span>
+          x-text="total + ' sessions'"></span>
   </div>
 
   <template x-if="loading">
@@ -81,6 +81,16 @@
     </div>
   </template>
 
+  <!-- Pager -->
+  <template x-if="!loading && total > limit">
+    <div class="row" style="margin-top:14px;gap:8px;align-items:center">
+      <button class="btn btn--ghost" :disabled="page <= 1" @click="goPage(page - 1)">← prev</button>
+      <span class="mono muted" style="font-size:12px"
+            x-text="'page ' + page + ' of ' + Math.ceil(total / limit)"></span>
+      <button class="btn btn--ghost" :disabled="page >= Math.ceil(total / limit)" @click="goPage(page + 1)">next →</button>
+    </div>
+  </template>
+
 </div>
 
 <style>
@@ -101,7 +111,9 @@
 function sessionsPage() {
   return {
     rows: [],
-    count: 0,
+    total: 0,
+    limit: 50,
+    page: 1,
     loading: false,
     search: '',
     agentFilter: '',
@@ -109,16 +121,23 @@ function sessionsPage() {
     async load() {
       this.loading = true;
       try {
-        let url = '/api/sessions?limit=200';
+        const offset = (this.page - 1) * this.limit;
+        let url = `/api/sessions?limit=${this.limit}&offset=${offset}`;
         if (this.search) url += '&search=' + encodeURIComponent(this.search);
         if (this.agentFilter) url += '&agent=' + encodeURIComponent(this.agentFilter);
         const r = await fetch(url);
         const d = await r.json();
         this.rows  = d.sessions || [];
-        this.count = d.count || 0;
+        this.total = d.total || 0;
+        this.limit = d.limit || this.limit;
       } finally {
         this.loading = false;
       }
+    },
+
+    goPage(n) {
+      this.page = n;
+      this.load();
     },
 
     fmtTime(ms) {

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -44,60 +44,79 @@ def _seed(conn: sqlite3.Connection) -> None:
 
 class TestQuerySessions:
     def test_returns_all_sessions(self, db):
-        rows = query_sessions(db)
+        rows, total = query_sessions(db)
         assert len(rows) == 2
+        assert total == 2
 
     def test_session_fields(self, db):
-        rows = query_sessions(db)
+        rows, _ = query_sessions(db)
         ids = {r["id"] for r in rows}
         assert _SID_A in ids
         assert _SID_B in ids
 
     def test_span_count(self, db):
-        rows = query_sessions(db)
+        rows, _ = query_sessions(db)
         row_a = next(r for r in rows if r["id"] == _SID_A)
         assert row_a["span_count"] == 2
 
     def test_token_sum(self, db):
-        rows = query_sessions(db)
+        rows, _ = query_sessions(db)
         row_a = next(r for r in rows if r["id"] == _SID_A)
         assert row_a["total_tokens"] == 600  # 100+0 + 400+100
 
     def test_cost_sum(self, db):
-        rows = query_sessions(db)
+        rows, _ = query_sessions(db)
         row_a = next(r for r in rows if r["id"] == _SID_A)
         assert abs(row_a["total_cost_usd"] - 0.011) < 1e-9
 
     def test_has_outlier_flag(self, db):
-        rows = query_sessions(db)
+        rows, _ = query_sessions(db)
         row_a = next(r for r in rows if r["id"] == _SID_A)
         assert row_a["has_outlier"] == 1
 
     def test_no_outlier_flag(self, db):
-        rows = query_sessions(db)
+        rows, _ = query_sessions(db)
         row_b = next(r for r in rows if r["id"] == _SID_B)
         assert row_b["has_outlier"] == 0
 
     def test_filter_by_agent(self, db):
-        rows = query_sessions(db, agent="codex")
+        rows, total = query_sessions(db, agent="codex")
         assert len(rows) == 1
+        assert total == 1
         assert rows[0]["id"] == _SID_B
 
     def test_filter_by_search(self, db):
         partial = _SID_A[:8]
-        rows = query_sessions(db, search=partial)
+        rows, total = query_sessions(db, search=partial)
         assert len(rows) == 1
+        assert total == 1
         assert rows[0]["id"] == _SID_A
 
     def test_limit(self, db):
-        rows = query_sessions(db, limit=1)
+        rows, total = query_sessions(db, limit=1)
         assert len(rows) == 1
+        assert total == 2  # total unchanged despite limit
+
+    def test_offset(self, db):
+        rows_p1, total = query_sessions(db, limit=1, offset=0)
+        rows_p2, _ = query_sessions(db, limit=1, offset=1)
+        assert total == 2
+        assert len(rows_p1) == 1
+        assert len(rows_p2) == 1
+        assert rows_p1[0]["id"] != rows_p2[0]["id"]
+
+    def test_offset_beyond_total(self, db):
+        rows, total = query_sessions(db, limit=50, offset=100)
+        assert rows == []
+        assert total == 2
 
     def test_empty_db(self):
         conn = sqlite3.connect(":memory:")
         conn.row_factory = sqlite3.Row
         init_db(conn)
-        assert query_sessions(conn) == []
+        rows, total = query_sessions(conn)
+        assert rows == []
+        assert total == 0
         conn.close()
 
     def test_session_with_no_spans(self):
@@ -110,7 +129,8 @@ class TestQuerySessions:
             (sid, "claude_code", 1_700_000_000_000),
         )
         conn.commit()
-        rows = query_sessions(conn)
+        rows, total = query_sessions(conn)
         assert len(rows) == 1
+        assert total == 1
         assert rows[0]["span_count"] == 0
         conn.close()


### PR DESCRIPTION
Closes #163

Adds `offset` param + `total` to `GET /api/sessions`. Default page size 50. Frontend pager shows prev/next + page X of Y. Preserves active search/filter/agent on page nav. Tests updated + pagination tests added.