### PR TITLE
fix(settings): session counts disagree between Providers and Data sections

### DIFF
--- a/burnmap/api/backfill.py
+++ b/burnmap/api/backfill.py
@@ -427,12 +427,21 @@ def run_backfill(conn: sqlite3.Connection) -> dict[str, Any]:
 # ── Status (read-only) ────────────────────────────────────────────────────────
 
 def query_backfill_status(conn: sqlite3.Connection) -> dict[str, Any]:
-    """Return current ingestion counts and file discovery totals."""
-    row = conn.execute(
+    """Return current ingestion counts and file discovery totals.
+
+    sessions_ingested counts rows in the sessions table (same source as the
+    Providers section) so both UI sections agree on the session total.
+    spans_ingested counts distinct session_id values in spans (sessions with
+    usable data), reported separately for transparency.
+    """
+    session_row = conn.execute(
+        "SELECT COUNT(*) AS s FROM sessions"
+    ).fetchone()
+    span_row = conn.execute(
         "SELECT COUNT(DISTINCT session_id) AS s, COUNT(*) AS sp FROM spans"
     ).fetchone()
-    sessions = row["s"] if row else 0
-    spans = row["sp"] if row else 0
+    sessions = session_row["s"] if session_row else 0
+    spans = span_row["sp"] if span_row else 0
     total_files = len(_discover_files())
     pct = 100 if total_files == 0 else min(100, round(sessions / total_files * 100))
     return {

--- a/burnmap/templates/pages/settings.html
+++ b/burnmap/templates/pages/settings.html
@@ -126,7 +126,7 @@
             <span>Source: <b class="mono">Claude Code / Codex / Cline / Aider JSONL logs</b></span>
             <span class="spacer"></span>
             <span class="mono muted" style="font-size:11px"
-              x-text="backfill ? 'last refresh · ' + backfill.sessions_ingested + ' sessions · ' + backfill.spans_ingested + ' spans' : ''">
+              x-text="backfill ? 'last refresh · ' + backfill.sessions_ingested + ' discovered sessions · ' + backfill.spans_ingested + ' spans' : ''">
             </span>
           </div>
           <div class="row" style="margin-top:12px;gap:8px">

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from burnmap.api.settings import query_storage_info, query_providers, query_pricing_info
+from burnmap.api.backfill import query_backfill_status
 
 
 @pytest.fixture()
@@ -148,3 +149,35 @@ class TestQueryPricingInfo:
             # Should not raise
             result = query_pricing_info()
         assert "model_count" in result
+
+
+class TestSessionCountConsistency:
+    """Providers and Data sections must agree on session count (issue #161)."""
+
+    def test_providers_total_matches_backfill_sessions_ingested(self, conn):
+        # Insert 2 sessions: one with spans (usable), one without (empty/malformed)
+        sid_a = str(uuid.uuid4())
+        sid_b = str(uuid.uuid4())
+        conn.execute("INSERT INTO sessions(id, agent) VALUES (?, 'claude_code')", (sid_a,))
+        conn.execute("INSERT INTO sessions(id, agent) VALUES (?, 'codex')", (sid_b,))
+        conn.execute(
+            "INSERT INTO spans(id, session_id, agent, kind, name) VALUES (?, ?, 'claude_code', 'turn', 'x')",
+            (str(uuid.uuid4()), sid_a),
+        )
+        conn.commit()
+
+        fake_adapters = [
+            {"agent": "claude_code", "found": True, "path": "/p", "checked_paths": []},
+            {"agent": "codex", "found": True, "path": "/q", "checked_paths": []},
+        ]
+        with patch("burnmap.api.settings.discover_adapters", return_value=fake_adapters):
+            providers = query_providers(conn)
+        providers_total = sum(p["sessions"] for p in providers)
+
+        with patch("burnmap.api.backfill._discover_files", return_value=[]):
+            status = query_backfill_status(conn)
+
+        assert providers_total == status["sessions_ingested"], (
+            f"Providers total ({providers_total}) != backfill sessions_ingested "
+            f"({status['sessions_ingested']})"
+        )


### PR DESCRIPTION
Root cause: Providers counted from sessions table, Data counted from spans (sessions with usable data). Fix: query_backfill_status now counts from sessions table — single source of truth.

Decision: sessions table is canonical for "discovered sessions". Data section label updated to "discovered sessions" for transparency.

Closes #161