### PR TITLE
feat: add /alerts route for outlier review page

### DIFF
--- a/burnmap/api/web.py
+++ b/burnmap/api/web.py
@@ -133,6 +133,11 @@ if _FASTAPI:
     def outliers(request: Request) -> HTMLResponse:
         return _html(request, "pages/outliers.html")
 
+    @router.get("/alerts", response_class=HTMLResponse)
+    def alerts(request: Request) -> HTMLResponse:
+        """Outlier review page — all flagged runs, sortable by sigma (PRD P1)."""
+        return _html(request, "pages/outliers.html")
+
     @router.get("/settings", response_class=HTMLResponse)
     def settings(request: Request) -> HTMLResponse:
         return _html(request, "pages/settings.html")

--- a/tests/test_alerts_route.py
+++ b/tests/test_alerts_route.py
@@ -1,0 +1,24 @@
+"""Tests for GET /alerts — outlier review page (PRD P1)."""
+import pytest
+from fastapi.testclient import TestClient
+from burnmap.app import create_app
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(create_app(), headers={"host": "localhost"})
+
+
+def test_alerts_returns_200(client):
+    resp = client.get("/alerts")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_alerts_and_outliers_same_content(client):
+    """Both routes must serve the same outlier review page."""
+    alerts_resp = client.get("/alerts")
+    outliers_resp = client.get("/outliers")
+    assert alerts_resp.status_code == 200
+    assert outliers_resp.status_code == 200
+    assert alerts_resp.text == outliers_resp.text


### PR DESCRIPTION
## Summary

Adds `/alerts` as a route alias for the outlier review page (`/outliers`), per PRD requirement: "Outlier review page — all flagged runs, sortable by sigma (P1)".

## Changes

- `burnmap/api/web.py`: Added `GET /alerts` handler serving `pages/outliers.html`
- `tests/test_alerts_route.py`: Two tests — 200 response + content parity with `/outliers`

## Testing

All 486 tests pass.

Closes #195