### PR TITLE
test: add HTTP smoke tests for HTML page routes

### DIFF
--- a/burnmap/api/web.py
+++ b/burnmap/api/web.py
@@ -104,7 +104,8 @@ if _FASTAPI:
                 if trace:
                     return _html(request, "pages/trace_tree.html", trace=trace)
             # Fallback: render with empty trace
-            return _html(request, "pages/trace_tree.html", trace={"id": None, "label": "No traces", "total_tokens": 0, "total_cost": 0, "turns": 0, "tools": 0, "tree": []})
+            empty_tree = {"id": None, "label": "No traces", "kind": "session", "tokens": 0, "cost": 0.0, "loop": False, "started_at": 0, "ended_at": 0, "children": []}
+            return _html(request, "pages/trace_tree.html", trace={"id": None, "label": "No traces", "total_tokens": 0, "total_cost": 0, "duration_ms": 0, "turns": 0, "tools": 0, "tree": empty_tree})
         finally:
             db.close()
 

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1,0 +1,94 @@
+"""Smoke tests for HTML page routes in burnmap/api/web.py (PRD UI P0)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from burnmap.app import create_app
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(create_app(), headers={"host": "localhost"})
+
+
+def _mock_db():
+    db = MagicMock()
+    db.execute.return_value.fetchone.return_value = None
+    return db
+
+
+# ── simple routes (no DB) ────────────────────────────────────────────────────
+
+def test_overview_returns_200(client):
+    resp = client.get("/overview")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_prompts_returns_200(client):
+    resp = client.get("/prompts")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_prompt_detail_returns_200(client):
+    resp = client.get("/prompts/abc123")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_tasks_returns_200(client):
+    resp = client.get("/tasks")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_settings_returns_200(client):
+    resp = client.get("/settings")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_favicon_returns_204(client):
+    resp = client.get("/favicon.ico")
+    assert resp.status_code == 204
+
+
+# ── DB-dependent routes ───────────────────────────────────────────────────────
+
+def test_index_returns_200_when_not_first_run(client):
+    with (
+        patch("burnmap.db.schema.get_db", return_value=_mock_db()),
+        patch("burnmap.api.backfill.is_first_run", return_value=False),
+    ):
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_index_redirects_on_first_run(client):
+    with (
+        patch("burnmap.db.schema.get_db", return_value=_mock_db()),
+        patch("burnmap.api.backfill.is_first_run", return_value=True),
+    ):
+        resp = client.get("/", follow_redirects=False)
+    assert resp.status_code in (302, 307)
+
+
+def test_trace_returns_200_with_empty_db(client):
+    with patch("burnmap.db.schema.get_db", return_value=_mock_db()):
+        resp = client.get("/trace")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+
+def test_trace_detail_returns_404_for_missing_trace(client):
+    with (
+        patch("burnmap.db.schema.get_db", return_value=_mock_db()),
+        patch("burnmap.api.trace.query_trace", return_value=None),
+    ):
+        resp = client.get("/trace/nonexistent-id")
+    assert resp.status_code == 404


### PR DESCRIPTION
Closes #198

## Changes
- `tests/test_web_routes.py` — 10 smoke tests covering all 9 untested HTML routes
- `burnmap/api/web.py` — fixes two bugs in `/trace` empty-state fallback (missing `duration_ms`, `tree` was a list instead of root node object)

## Routes covered
| Route | Test |
|---|---|
| `GET /` | not-first-run → 200 HTML; first-run → 302 redirect |
| `GET /overview` | 200 HTML |
| `GET /prompts` | 200 HTML |
| `GET /prompts/{fingerprint}` | 200 HTML |
| `GET /tasks` | 200 HTML |
| `GET /settings` | 200 HTML |
| `GET /favicon.ico` | 204 |
| `GET /trace` | 200 HTML (empty-DB fallback) |
| `GET /trace/{trace_id}` | 404 for missing trace |

The `/trace` tests also surfaced and fixed a latent rendering crash in the empty-state fallback path.