### PR TITLE
docs: add OSS marketing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # t01-burnmap
 
-Local-first dashboard that tracks AI coding agent token usage and attributes cost per prompt down to individual tool invocations and subagent calls. Supports Claude Code, Codex CLI, Cline, and Aider.
+Your coding agents are spending tokens. `t01-burnmap` shows where they went.
+
+Local-first dashboard that tracks AI coding-agent token usage and attributes cost per prompt down to individual tool invocations and subagent calls. Planned support includes Claude Code, Codex CLI, Cline, and Aider.
+
+Token bills are not observability. `t01-burnmap` is designed to show where spend happens — prompts, tools, subagents, retries, and long loops — so agentic coding workflows can be debugged instead of guessed at.
 
 **Status:** planning / pre-alpha. No code yet — design docs are complete.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Token bills are not observability. `t01-burnmap` is designed to show where spend
 
 ## Docs
 
+- **Manual:** [`docs/manual.md`](./docs/manual.md)
+- **Showcases:** [`docs/showcases.md`](./docs/showcases.md)
 - **PRD:** [`docs-t01-burnmap/01-prd/`](./docs-t01-burnmap/01-prd/)
 - **Mockups:** [`docs-t01-burnmap/mockups/`](./docs-t01-burnmap/mockups/)
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,0 +1,57 @@
+# t01-burnmap manual
+
+`t01-burnmap` is a local-first dashboard for understanding where AI coding-agent tokens and costs go. It is currently planning / pre-alpha; this manual describes the intended user workflow.
+
+## 1. Install and start
+
+Planned install flow:
+
+```bash
+pipx install t01-burnmap
+t01-burnmap serve
+```
+
+The dashboard runs locally and reads supported agent logs from your machine.
+
+## 2. First-run setup
+
+On first run, `t01-burnmap` should help you:
+
+- discover supported providers and local log paths
+- backfill existing sessions where possible
+- estimate costs from token usage and provider pricing
+- land on an overview dashboard
+
+## 3. Read the overview
+
+The overview answers the daily question: where did the spend go?
+
+Expected top-level metrics include:
+
+- tokens today
+- estimated cost today
+- cost this block or session
+- cost this week
+- cache-hit rate where available
+
+## 4. Investigate a spike
+
+When spend looks unusual:
+
+1. Open the prompts or sessions view.
+2. Sort by cost.
+3. Drill into the expensive item.
+4. Inspect tool calls, subagent activity, retries, and loops.
+5. Decide whether to change prompts, slash commands, skills, or agent instructions.
+
+## 5. Find repeated work
+
+Duplicate or near-duplicate prompts are a signal that workflow should be extracted into a reusable command, script, or skill. `t01-burnmap` is meant to make those repeats visible.
+
+## 6. Export data
+
+Planned exports include CSV over a selected date range. Exports are intended for personal analysis, budget review, and workflow cleanup.
+
+## Privacy model
+
+`t01-burnmap` is designed to run locally. A privacy wipe command is planned so prompt snippets can be removed while keeping fingerprints and aggregate statistics.

--- a/docs/showcases.md
+++ b/docs/showcases.md
@@ -1,0 +1,52 @@
+# t01-burnmap showcases
+
+These examples show public, user-facing ways `t01-burnmap` is intended to help developers understand AI coding-agent spend.
+
+## 1. Post-hoc budget-spike analysis
+
+**Situation:** A coding session cost much more than expected.
+
+**Workflow:**
+
+- Sort sessions or prompts by estimated cost.
+- Open the expensive item.
+- Inspect tool calls and subagent activity.
+- Look for retries, loops, or repeated context loading.
+
+**Outcome:** Find the workflow pattern that caused the spike and adjust prompts, commands, or agent instructions.
+
+## 2. Tool-level cost analysis
+
+**Situation:** You suspect one tool is driving most token usage.
+
+**Workflow:**
+
+- Open the tools view.
+- Sort tools by total estimated cost.
+- Compare frequency, average cost, and total cost.
+
+**Outcome:** Decide whether to rewrite tool instructions, reduce unnecessary calls, or move repeated work into scripts.
+
+## 3. Duplicate-prompt discovery
+
+**Situation:** You keep typing similar prompts across sessions.
+
+**Workflow:**
+
+- Group similar prompts by fingerprint or text preview.
+- Review repeated high-cost requests.
+- Convert stable repeats into reusable commands, templates, or skills.
+
+**Outcome:** Turn recurring manual prompting into a cleaner workflow.
+
+## 4. Weekly cost review
+
+**Situation:** You want a lightweight review of coding-agent usage.
+
+**Workflow:**
+
+- Filter to the last week.
+- Review total cost, expensive sessions, and repeated prompts.
+- Export CSV for your notes if needed.
+
+**Outcome:** Keep AI coding spend visible without sending your logs to a hosted analytics service.


### PR DESCRIPTION
## Summary
- Refines the public README positioning copy.
- Adds public end-user docs: manual and showcases.
- Keeps internal marketing calendar, launch-plan, and messaging-resource files out of the public branch.

## Scope
Public README/manual/showcase content only.

## Test Plan
- Documentation-only change.
- Verified changed files are public-facing docs only.