### PR TITLE
fix: add pattern validation to GET /api/tasks kind parameter

### DIFF
--- a/burnmap/api/tasks.py
+++ b/burnmap/api/tasks.py
@@ -26,7 +26,7 @@ if _FASTAPI:
 
     @router.get("/api/tasks")
     def list_tasks(
-        kind: str | None = Query(None, description="Filter by kind: slash|skill|subagent"),
+        kind: str | None = Query(None, pattern="^(slash|skill|subagent)$", description="Filter by kind: slash|skill|subagent"),
         agent: str | None = Query(None, description="Filter by agent name"),
         limit: int = Query(100, ge=1, le=1000),
         db: sqlite3.Connection = Depends(_db),

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -2,8 +2,10 @@
 import sqlite3
 
 import pytest
+from fastapi.testclient import TestClient
 
 from burnmap.api.tasks import query_tasks, _VALID_KINDS
+from burnmap.app import create_app
 from burnmap.db.schema import init_db
 
 
@@ -118,3 +120,16 @@ class TestQueryTasks:
         init_db(conn)
         assert query_tasks(conn) == []
         conn.close()
+
+
+class TestTasksRoute:
+    def test_invalid_kind_returns_422(self):
+        client = TestClient(create_app(), headers={"host": "localhost"})
+        resp = client.get("/api/tasks?kind=invalid")
+        assert resp.status_code == 422
+
+    def test_valid_kind_returns_200(self):
+        client = TestClient(create_app(), headers={"host": "localhost"})
+        resp = client.get("/api/tasks?kind=slash")
+        assert resp.status_code == 200
+        assert "tasks" in resp.json()


### PR DESCRIPTION
Closes #205

## Changes
- Added regex pattern constraint to `kind` Query parameter in `GET /api/tasks`
- Pattern `^(slash|skill|subagent)$` now enforced at route level
- Invalid `kind` values return HTTP 422 (validation error) instead of 200 + empty list
- Added HTTP-level tests to verify 422 behavior

## Matches Issue Criteria
✓ Constraint added via `Query(pattern=...)`
✓ Returns 422 for invalid input (consistent with `/api/export?format=evil`)
✓ Test coverage for 422 path added