### PR TITLE
feat: show model name next to price in indented tree rows

### DIFF
--- a/burnmap/api/trace.py
+++ b/burnmap/api/trace.py
@@ -127,7 +127,7 @@ def query_trace(
         dict(r)
         for r in conn.execute(
             """SELECT id, parent_id, kind, name, input_tokens, output_tokens,
-                      cost_usd, started_at, ended_at, is_outlier
+                      cost_usd, started_at, ended_at, is_outlier, model
                FROM spans WHERE session_id = ? ORDER BY started_at ASC""",
             (session_id,),
         ).fetchall()

--- a/burnmap/db/schema.py
+++ b/burnmap/db/schema.py
@@ -146,6 +146,8 @@ def init_db(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE spans ADD COLUMN ended_at INTEGER DEFAULT 0")
     if "is_outlier" not in cols:
         conn.execute("ALTER TABLE spans ADD COLUMN is_outlier INTEGER DEFAULT 0")
+    if "model" not in cols:
+        conn.execute("ALTER TABLE spans ADD COLUMN model TEXT")
     # Additive migration: agents/projects columns on prompts (for upgraded DBs)
     prompt_cols = {row[1] for row in conn.execute("PRAGMA table_info(prompts)")}
     if "agents" not in prompt_cols:

--- a/burnmap/templates/pages/trace_tree.html
+++ b/burnmap/templates/pages/trace_tree.html
@@ -77,7 +77,7 @@
       {% set tok = node.tokens if node.tokens else 0 %}
       <span class="indent-cost-fill" style="width: {{ [(tok / 10), 120] | min }}px;"></span>
     </span>
-    <span class="indent-stats mono muted">{{ tok }} tok · ${{ "%.4f"|format(node.cost if node.cost else 0) }}</span>
+    <span class="indent-stats mono muted">{{ tok }} tok · ${{ "%.4f"|format(node.cost if node.cost else 0) }}{% if node.model %} · <span style="color: var(--ink-3); max-width: 14ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-block; vertical-align: bottom;" title="{{ node.model }}">{{ node.model }}</span>{% endif %}</span>
   {% endif %}
 </div>
 {% for child in node.children %}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -64,9 +64,9 @@ class TestCoreTables:
     def test_spans_crud_with_parent(self, conn):
         conn.execute("INSERT INTO sessions VALUES ('s1', 'claude_code', 0, 0)")
         conn.execute("""INSERT INTO spans
-            VALUES ('sp1', 's1', 'claude_code', 'turn', 'main', NULL, 5, 10, 0.001, 100, 200, 0)""")
+            VALUES ('sp1', 's1', 'claude_code', 'turn', 'main', NULL, 5, 10, 0.001, 100, 200, 0, NULL)""")
         conn.execute("""INSERT INTO spans
-            VALUES ('sp2', 's1', 'claude_code', 'tool', 'Bash', 'sp1', 2, 3, 0.0005, 110, 150, 0)""")
+            VALUES ('sp2', 's1', 'claude_code', 'tool', 'Bash', 'sp1', 2, 3, 0.0005, 110, 150, 0, NULL)""")
         conn.commit()
         parent = conn.execute("SELECT parent_id FROM spans WHERE id='sp2'").fetchone()[0]
         assert parent == "sp1"
@@ -87,7 +87,7 @@ class TestCoreTables:
     def test_span_events_crud(self, conn):
         conn.execute("INSERT INTO sessions VALUES ('s1', 'claude_code', 0, 0)")
         conn.execute("""INSERT INTO spans
-            VALUES ('sp1', 's1', 'claude_code', 'turn', 'main', NULL, 0, 0, 0.0, 0, 0, 0)""")
+            VALUES ('sp1', 's1', 'claude_code', 'turn', 'main', NULL, 0, 0, 0.0, 0, 0, 0, NULL)""")
         conn.execute("INSERT INTO span_events VALUES ('ev1', 'sp1', 'hook_start', '{\"k\":1}', 100)")
         conn.commit()
         row = conn.execute("SELECT * FROM span_events WHERE id='ev1'").fetchone()

--- a/tests/test_trace_api.py
+++ b/tests/test_trace_api.py
@@ -204,6 +204,7 @@ class Span:
     stdev_cost: float = 0.0
     started_at: int = 0
     ended_at: int = 0
+    model: str | None = None
     children: list[Any] = field(default_factory=list)
 
 @dataclass
@@ -269,6 +270,30 @@ class TestTraceTreeTemplate:
         out = tmpl.render(trace=trace)
         assert "loop" in out
         assert "×7" in out
+
+    def test_model_name_shown_in_indented_row(self, env):
+        """Indented row should display model name when present."""
+        tool = Span(id="s2", label="Read", kind="tool", tokens=100, cost=0.001,
+                    attribution="exact", model="claude-opus-4-7")
+        root = Span(id="s1", label="root turn", kind="turn", tokens=500, cost=0.01,
+                    attribution="exact", model="claude-sonnet-4-6", children=[tool])
+        trace = Trace(id="t", label="root turn", total_tokens=600, total_cost=0.011,
+                      duration_ms=0, turns=1, tools=1, tree=root)
+        tmpl = env.get_template("pages/trace_tree.html")
+        out = tmpl.render(trace=trace)
+        assert "claude-opus-4-7" in out
+        assert "claude-sonnet-4-6" in out
+
+    def test_model_name_omitted_when_none(self, env):
+        """Indented row should not show model span when model is None."""
+        root = Span(id="s1", label="root", kind="turn", tokens=100, cost=0.005,
+                    attribution="exact", model=None)
+        trace = Trace(id="t", label="root", total_tokens=100, total_cost=0.005,
+                      duration_ms=0, turns=1, tools=0, tree=root)
+        tmpl = env.get_template("pages/trace_tree.html")
+        out = tmpl.render(trace=trace)
+        # model span should be absent
+        assert "max-width: 14ch" not in out
 
     def test_empty_tree_no_spans_message(self, env):
         # A trace with tree=None should show "no spans" in icicle + indented panels


### PR DESCRIPTION
## Summary

Adds model name display to indented tree rows in the trace tree page.

- Adds `model` column to `spans` table via additive migration
- Fetches `model` in `query_trace` SELECT, passes through `_build_tree`
- Template shows `· claude-opus-4-7` beside price; truncates at 14ch to fit narrow widths
- Rows with no model (synthetic/parent spans) omit the field gracefully
- 2 new template tests (model shown, model omitted); fixed 2 raw-INSERT tests in test_schema.py

Closes #213