### PR TITLE
docs: drop icicle/flame & waterfall from PRD, keep indented-only

### DIFF
--- a/docs-t01-burnmap/01-prd/02-scope.md
+++ b/docs-t01-burnmap/01-prd/02-scope.md
@@ -6,7 +6,7 @@
 - **Provider management** — Settings > Providers list with detail sub-pages. Add/configure/rescan/remove. Global agent filter in topbar.
 - **Prompt fingerprinting** — SHA-256 over normalized text. Aggregation table: run count, tokens, cost, agents, projects.
 - **Tree reconstruction** — OpenTelemetry-aligned spans (prompt -> turn -> tool -> subagent -> recurse).
-- **Icicle + indented tree views** — two complementary visualizations, synced selection.
+- **Indented tree view** — span hierarchy with collapsible rows and synced selection.
 - **Attribution labels** — `exact` / `apportioned` / `inherited` as colored badges (green / amber / gray) on each span.
 - **Content-mode privacy** — two modes (`preview` default, `full` opt-in). SHA-256 fingerprint always stored. One-command wipe drops snippets; fingerprints and aggregates are preserved.
 - **Cost estimation** — effective-dated LiteLLM pricing. Subscription runs labeled synthetic, API runs labeled real.

--- a/docs-t01-burnmap/01-prd/05-requirements.md
+++ b/docs-t01-burnmap/01-prd/05-requirements.md
@@ -11,7 +11,7 @@
 | **Pricing** | Subscription = synthetic, API = real | P0 |
 | **Tree** | Span reconstruction per agent at feasible depth | P0 |
 | **Tree** | Attribution badges: `exact` (green) / `apportioned` (amber) / `inherited` (gray) | P0 |
-| **Tree** | Icicle + indented views over same data | P0 |
+| **Tree** | Indented tree view with collapsible rows | P0 |
 | **Tree** | Loop-collapse (>= 4 identical siblings) | P1 |
 | **Tree** | Stuck-loop detection (>= 20 identical, or cost trending up) | P1 |
 | **Prompts** | Fingerprinting, aggregates table, list page | P0 |

--- a/docs-t01-burnmap/01-prd/07-phases.md
+++ b/docs-t01-burnmap/01-prd/07-phases.md
@@ -11,7 +11,7 @@ Sequential phases. Each ends with a shippable milestone.
 | **P2.75** | Tree reconstruction + subagent handling | 8–12 | parentUuid walker, sidechain merge, apportionment rules |
 | **P2.9** | Precision mode (Claude hooks) | 8–12 | Hook installer, Unix socket receiver, `span_events` merge |
 | **P4** | Prompts page + drill-down | 8–12 | List, filters, detail, histogram, outlier flags |
-| **P4.5** | Tree views: icicle + indented | 10–16 | Two views over one data source, loop-collapse rule |
+| **P4.5** | Tree view: indented | 6–10 | Indented tree over one data source, loop-collapse rule |
 | **P5** | Tasks page + slash / skill extraction | 6–10 | Same shape as prompts, over `agent_tasks` |
 | **P6** | Outlier nightly + top-N widgets | 3–5 | 2σ sweep, "this week" widgets, stuck-loop UI |
 | **P6.5** | Tool aggregates + cross-prompt page | 4–6 | Per-tool cost rollup |

--- a/docs-t01-burnmap/01-prd/09-open-questions.md
+++ b/docs-t01-burnmap/01-prd/09-open-questions.md
@@ -8,4 +8,4 @@
 
 - **Aider multi-repo walk.** Default `$HOME` depth 3, or force explicit config? Leaning explicit.
 
-- **Waterfall view data.** Span start/end timestamps needed for Gantt-style waterfall. Confirm adapters can extract absolute timestamps, or fall back to token-proportional offsets.
+- ~~**Waterfall view data.**~~ Dropped — waterfall tab removed; indented tree is the only trace visualization.


### PR DESCRIPTION
Closes #210

## Changes
- 02-scope.md: replaced icicle+indented with indented-only
- 05-requirements.md: updated Tree FR to indented-only
- 07-phases.md: P4.5 renamed to indented-only, hours adjusted
- 09-open-questions.md: waterfall question struck out as dropped

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>