### PR TITLE
feat: statusline command for Claude Code integration

### DIFF
--- a/burnmap/cli.py
+++ b/burnmap/cli.py
@@ -18,6 +18,7 @@ def main() -> None:
         print("  token         Manage auth tokens (--create)")
         print("  serve         Start the FastAPI server (--host, --port, --reload)")
         print("  content       Manage prompt content (wipe, mode)")
+        print("  statusline    Emit one-line summary for Claude Code statusline API")
         return
 
     if args[0] == "token":
@@ -26,6 +27,8 @@ def main() -> None:
         _cmd_serve(args[1:])
     elif args[0] == "content":
         _cmd_content(args[1:])
+    elif args[0] == "statusline":
+        _cmd_statusline()
     elif args[0] == "sweep":
         conn = get_db()
         init_db(conn)
@@ -84,6 +87,48 @@ def _cmd_content(args: list[str]) -> None:
     else:
         print(f"Unknown content subcommand: {args[0]}", file=sys.stderr)
         sys.exit(1)
+
+
+def _cmd_statusline() -> None:
+    """Emit a one-line burnmap summary for Claude Code's statusline API.
+
+    Output format: "burnmap | N sessions · $X.XXXX today · A live"
+    Non-blocking: returns immediately with stale data on DB error.
+    """
+    import time
+    try:
+        conn = get_db()
+        init_db(conn)
+        now_ms = int(time.time() * 1000)
+        day_ms = 24 * 60 * 60 * 1000
+        hour_ms = 60 * 60 * 1000
+
+        # Sessions in last 24h
+        row = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE started_at >= ?",
+            (now_ms - day_ms,),
+        ).fetchone()
+        session_count = row[0] if row else 0
+
+        # Total cost from spans in last 24h
+        row = conn.execute(
+            "SELECT COALESCE(SUM(cost_usd), 0) FROM spans WHERE started_at >= ?",
+            (now_ms - day_ms,),
+        ).fetchone()
+        cost_today = row[0] if row else 0.0
+
+        # Live agents: sessions started in last hour with no ended_at
+        row = conn.execute(
+            "SELECT COUNT(DISTINCT agent) FROM sessions "
+            "WHERE started_at >= ? AND (ended_at = 0 OR ended_at IS NULL)",
+            (now_ms - hour_ms,),
+        ).fetchone()
+        live_agents = row[0] if row else 0
+
+        conn.close()
+        print(f"burnmap | {session_count} sessions · ${cost_today:.4f} today · {live_agents} live")
+    except Exception:
+        print("burnmap | unavailable")
 
 
 def _cmd_serve(args: list[str]) -> None:

--- a/tests/test_statusline.py
+++ b/tests/test_statusline.py
@@ -1,0 +1,89 @@
+"""Tests for `burnmap statusline` CLI command — issue #208."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from unittest.mock import patch
+
+import pytest
+
+from burnmap.cli import _cmd_statusline
+from burnmap.db.schema import init_db
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    init_db(conn)
+    return conn
+
+
+def _seed(conn: sqlite3.Connection, *, n_sessions: int = 2, cost: float = 0.05,
+          live: bool = False) -> None:
+    now_ms = int(time.time() * 1000)
+    for i in range(n_sessions):
+        sid = f"s{i}"
+        ended = 0 if (live and i == 0) else now_ms - 1000
+        conn.execute(
+            "INSERT INTO sessions (id, agent, started_at, ended_at) VALUES (?,?,?,?)",
+            (sid, "claude_code", now_ms - 60_000, ended),
+        )
+        conn.execute(
+            "INSERT INTO spans (id, session_id, agent, kind, name, parent_id, "
+            "input_tokens, output_tokens, cost_usd, started_at, ended_at, is_outlier) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+            (f"sp{i}", sid, "claude_code", "turn", "root", None,
+             10, 5, cost / n_sessions, now_ms - 60_000, now_ms - 1000, 0),
+        )
+    conn.commit()
+
+
+class TestStatuslineOutput:
+    def test_normal_output_format(self, capsys):
+        conn = _make_conn()
+        _seed(conn, n_sessions=3, cost=0.012)
+        with patch("burnmap.cli.get_db", return_value=conn), \
+             patch("burnmap.cli.init_db"):
+            _cmd_statusline()
+        out = capsys.readouterr().out.strip()
+        assert out.startswith("burnmap |")
+        assert "sessions" in out
+        assert "today" in out
+        assert "live" in out
+
+    def test_session_count_in_output(self, capsys):
+        conn = _make_conn()
+        _seed(conn, n_sessions=4, cost=0.02)
+        with patch("burnmap.cli.get_db", return_value=conn), \
+             patch("burnmap.cli.init_db"):
+            _cmd_statusline()
+        out = capsys.readouterr().out.strip()
+        assert "4 sessions" in out
+
+    def test_cost_shown_in_output(self, capsys):
+        conn = _make_conn()
+        _seed(conn, n_sessions=1, cost=0.1234)
+        with patch("burnmap.cli.get_db", return_value=conn), \
+             patch("burnmap.cli.init_db"):
+            _cmd_statusline()
+        out = capsys.readouterr().out.strip()
+        assert "$0.1234" in out
+
+    def test_db_error_prints_unavailable(self, capsys):
+        """If DB raises, emit 'burnmap | unavailable' without crashing."""
+        def _bad_db() -> None:
+            raise OSError("DB gone")
+        with patch("burnmap.cli.get_db", side_effect=OSError("DB gone")):
+            _cmd_statusline()
+        out = capsys.readouterr().out.strip()
+        assert out == "burnmap | unavailable"
+
+    def test_empty_db_zero_sessions(self, capsys):
+        conn = _make_conn()
+        with patch("burnmap.cli.get_db", return_value=conn), \
+             patch("burnmap.cli.init_db"):
+            _cmd_statusline()
+        out = capsys.readouterr().out.strip()
+        assert "0 sessions" in out
+        assert "$0.0000" in out


### PR DESCRIPTION
Closes #208

## Changes
- New `_cmd_statusline()` in burnmap/cli.py: queries DB for 24h session count, cost, live agents
- Added to `main()` dispatch + help text
- Non-blocking: prints 'burnmap | unavailable' on any DB error
- 5 new tests in tests/test_statusline.py (format, count, cost, error, empty)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>