### PR TITLE
chore: move Sessions to top of sidebar Analyze section

### DIFF
--- a/burnmap/templates/base.html
+++ b/burnmap/templates/base.html
@@ -34,6 +34,12 @@
     <!-- Analyze section -->
     <div class="rail__section">
       <div class="rail__label">Analyze</div>
+      <a href="/sessions" class="rail__link" :class="{'is-active': page === 'sessions'}">
+        <span class="rail__glyph">
+          <svg viewBox="0 0 14 14" width="14" height="14"><rect x="3" y="3" width="8" height="8" rx="1" fill="none" stroke="currentColor" stroke-width="1.4"/></svg>
+        </span>
+        <span>Sessions</span>
+      </a>
       <a href="/prompts" class="rail__link" :class="{'is-active': page === 'prompts'}">
         <span class="rail__glyph">
           <svg viewBox="0 0 14 14" width="14" height="14"><rect x="2" y="3" width="10" height="1.4" fill="currentColor"/><rect x="2" y="6.3" width="10" height="1.4" fill="currentColor"/><rect x="2" y="9.6" width="10" height="1.4" fill="currentColor"/></svg>
@@ -57,12 +63,6 @@
           <svg viewBox="0 0 14 14" width="14" height="14"><rect x="2" y="7" width="2" height="5" fill="currentColor"/><rect x="6" y="4" width="2" height="8" fill="currentColor"/><rect x="10" y="2" width="2" height="10" fill="currentColor"/></svg>
         </span>
         <span>Tools</span>
-      </a>
-      <a href="/sessions" class="rail__link" :class="{'is-active': page === 'sessions'}">
-        <span class="rail__glyph">
-          <svg viewBox="0 0 14 14" width="14" height="14"><rect x="3" y="3" width="8" height="8" rx="1" fill="none" stroke="currentColor" stroke-width="1.4"/></svg>
-        </span>
-        <span>Sessions</span>
       </a>
       <a href="/outliers" class="rail__link" :class="{'is-active': page === 'outliers'}">
         <span class="rail__glyph">

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -92,3 +92,15 @@ def test_trace_detail_returns_404_for_missing_trace(client):
     ):
         resp = client.get("/trace/nonexistent-id")
     assert resp.status_code == 404
+
+
+def test_sidebar_sessions_before_prompts(client):
+    """Sessions nav link should appear before Prompts in the sidebar."""
+    resp = client.get("/prompts")
+    assert resp.status_code == 200
+    html = resp.text
+    sessions_pos = html.find('href="/sessions"')
+    prompts_pos = html.find('href="/prompts"')
+    assert sessions_pos != -1, "Sessions link missing"
+    assert prompts_pos != -1, "Prompts link missing"
+    assert sessions_pos < prompts_pos, "Sessions should appear before Prompts in sidebar"


### PR DESCRIPTION
Closes #214

## Changes
- Reordered Analyze section nav links in base.html: Sessions → Prompts → Tasks → Trace tree → Tools → Outliers
- System section (Settings/Export) unchanged
- Added test: assert sessions link appears before prompts link in HTML

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>