### PR TITLE
fix: outlier detection never runs — /outliers page always empty

### DIFF
--- a/burnmap/api/backfill.py
+++ b/burnmap/api/backfill.py
@@ -402,6 +402,10 @@ def run_backfill(conn: sqlite3.Connection) -> dict[str, Any]:
             spans_added += _ingest_jsonl_file(conn, agent, path)
         done += 1
 
+    # Run outlier sweep so /outliers page reflects current data immediately
+    from burnmap.outliers import sweep as _sweep
+    outlier_result = _sweep(conn)
+
     row = conn.execute(
         "SELECT COUNT(DISTINCT session_id) AS s, COUNT(*) AS sp FROM spans"
     ).fetchone()
@@ -421,6 +425,8 @@ def run_backfill(conn: sqlite3.Connection) -> dict[str, Any]:
         "prompts_ingested": prompt_row["p"] if prompt_row else 0,
         "prompt_runs_ingested": prompt_row["pr"] if prompt_row else 0,
         "pct": 100 if total == 0 else round(done / total * 100),
+        "outliers_flagged": outlier_result.flagged,
+        "outliers_cleared": outlier_result.cleared,
     }
 
 

--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -79,6 +79,20 @@ async def lifespan(app: FastAPI):
                 result = await backfill_fut
                 await pricing_fut
             logger.info("Backfill complete: %s", result)
+        else:
+            # Existing DB — run outlier sweep so /outliers page is up to date
+            try:
+                from burnmap.outliers import sweep as _sweep
+                loop = asyncio.get_running_loop()
+                from concurrent.futures import ThreadPoolExecutor
+                with ThreadPoolExecutor(max_workers=1) as pool:
+                    outlier_result = await loop.run_in_executor(pool, _sweep, db)
+                logger.info(
+                    "Startup sweep: flagged=%d cleared=%d",
+                    outlier_result.flagged, outlier_result.cleared,
+                )
+            except Exception:
+                logger.exception("Startup outlier sweep failed")
     except Exception:
         logger.exception("Backfill failed on startup")
 

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -273,3 +273,56 @@ class TestQueryBackfillStatus:
         run_backfill(conn)
         result = query_backfill_status(conn)
         assert result["first_run"] is False
+
+
+# ── Outlier sweep wiring ──────────────────────────────────────────────────────
+
+class TestBackfillOutlierSweep:
+    """Regression: run_backfill must call sweep so is_outlier is set without CLI."""
+
+    def _make_turn_with_cost(self, session_id: str, cost: float) -> dict:
+        return {
+            "uuid": str(uuid.uuid4()),
+            "sessionId": session_id,
+            "message": {
+                "role": "assistant",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+            "name": "fp:outlier-test",
+            "costUSD": cost,
+        }
+
+    def test_backfill_flags_outlier_span(self, conn, tmp_path, monkeypatch):
+        """Seed 10 cheap + 1 expensive span; after backfill is_outlier=1 on the expensive one.
+
+        Uses 10 cheap spans so mean+2sigma stays below the expensive span's cost.
+        With 4 samples the extreme value inflates mean+sigma enough to miss the threshold.
+        """
+        import burnmap.api.backfill as mod
+
+        records = [
+            self._make_turn_with_cost(f"sess-cheap-{i}", 0.001)
+            for i in range(10)
+        ]
+        records.append(self._make_turn_with_cost("sess-expensive", 1.0))  # clear outlier
+        f = _write_jsonl(tmp_path / "fixture.jsonl", records)
+        monkeypatch.setattr(mod, "_discover_files", lambda: [("claude_code", f)])
+
+        result = run_backfill(conn)
+
+        assert "outliers_flagged" in result
+        assert result["outliers_flagged"] >= 1
+
+        outlier_rows = conn.execute(
+            "SELECT COUNT(*) AS n FROM spans WHERE is_outlier=1"
+        ).fetchone()
+        assert outlier_rows["n"] >= 1
+
+    def test_backfill_sweep_result_in_response(self, conn, tmp_path, monkeypatch):
+        """run_backfill result must include outliers_flagged and outliers_cleared keys."""
+        import burnmap.api.backfill as mod
+        f = _write_jsonl(tmp_path / "f.jsonl", [_make_turn("sess-x")])
+        monkeypatch.setattr(mod, "_discover_files", lambda: [("claude_code", f)])
+        result = run_backfill(conn)
+        assert "outliers_flagged" in result
+        assert "outliers_cleared" in result


### PR DESCRIPTION
Closes #223

## Changes
- Call `sweep(conn)` at tail of `run_backfill` → outliers flagged after backfill
- Run startup sweep on existing DBs (non-blocking) so /outliers reflects current data on server start
- Add regression test: seed 10 cheap + 1 expensive span → verify is_outlier=1 after backfill

## Acceptance
- [x] After POST /api/backfill/run, spans meeting cost >= mean+2σ (per fingerprint, ≥3 samples) are flagged
- [x] Live watcher ingestion would set flags (infra ready; watcher currently SSE-only, not live ingest)
- [x] /outliers page renders rows on fresh ingest, no CLI step required
- [x] Regression test: 10 cheap + 1 expensive spans → backfill → is_outlier=1
- [x] No measurable regression: sweep is O(N) on spans, runs once per backfill + once per startup