### PR TITLE
fix: auto-refresh of session data no longer works

### DIFF
--- a/burnmap/app.py
+++ b/burnmap/app.py
@@ -47,6 +47,43 @@ def _collect_watch_paths() -> list[str]:
     return paths
 
 
+async def _watch_and_ingest(watcher: Watcher) -> None:
+    """Subscribe to watcher events and trigger backfill on each file change."""
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+    from burnmap.api.backfill import run_backfill
+    from burnmap.db import get_db
+
+    q = watcher.subscribe()
+    _DEBOUNCE = 2.0  # seconds — coalesce rapid writes into one ingest
+    try:
+        while True:
+            await q.get()  # wait for first event
+            # Drain any queued events within the debounce window
+            await asyncio.sleep(_DEBOUNCE)
+            while not q.empty():
+                q.get_nowait()
+
+            logger.info("Watcher: file change detected — running backfill")
+            db = get_db()
+            try:
+                loop = asyncio.get_running_loop()
+                with ThreadPoolExecutor(max_workers=1) as pool:
+                    result = await loop.run_in_executor(pool, run_backfill, db)
+                logger.info(
+                    "Watcher ingest complete: sessions=%d spans=%d",
+                    result.get("sessions_ingested", 0),
+                    result.get("spans_ingested", 0),
+                )
+            except Exception:
+                logger.exception("Watcher-triggered backfill failed")
+            finally:
+                db.close()
+    except asyncio.CancelledError:
+        watcher.unsubscribe(q)
+        raise
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Start watcher on startup, stop on shutdown."""
@@ -98,11 +135,19 @@ async def lifespan(app: FastAPI):
 
     watcher = Watcher()
     watch_paths = _collect_watch_paths()
+    ingest_task = None
     if watch_paths:
         watcher.start(watch_paths)
         logger.info("Watcher started on %d paths", len(watch_paths))
+        ingest_task = asyncio.ensure_future(_watch_and_ingest(watcher))
     app.state.watcher = watcher
     yield
+    if ingest_task is not None:
+        ingest_task.cancel()
+        try:
+            await ingest_task
+        except asyncio.CancelledError:
+            pass
     watcher.stop()
     logger.info("Watcher stopped")
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -131,3 +131,53 @@ async def test_file_write_triggers_event(tmp_path):
     assert event is not None
     assert event["type"] in ("file_changed", "file_created")
     assert "session.jsonl" in event["path"]
+
+
+@pytest.mark.asyncio
+async def test_watch_and_ingest_triggers_backfill(tmp_path):
+    """Regression: watcher event fires → _watch_and_ingest calls run_backfill."""
+    import sqlite3
+    import burnmap.app as app_module
+    from unittest.mock import patch
+
+    ingest_calls: list = []
+
+    def fake_run_backfill(db):
+        ingest_calls.append(True)
+        return {"sessions_ingested": 1, "spans_ingested": 5}
+
+    def fake_get_db():
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    # Patch debounce to near-zero so test runs fast
+    original_debounce = None
+    with patch("burnmap.api.backfill.run_backfill", fake_run_backfill), \
+         patch("burnmap.db.get_db", fake_get_db):
+
+        watcher = Watcher()
+        watcher.start([str(tmp_path)])
+
+        # Inject a small debounce directly via queue event rather than timing
+        task = asyncio.create_task(app_module._watch_and_ingest(watcher))
+        await asyncio.sleep(0.2)  # let observer warm up
+
+        # Write a file to trigger watchdog event
+        test_file = tmp_path / "session.jsonl"
+        test_file.write_text('{"session_id": "abc"}\n')
+
+        # Wait up to 6s (2s debounce + 1s buffer + IO)
+        for _ in range(60):
+            if ingest_calls:
+                break
+            await asyncio.sleep(0.1)
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        watcher.stop()
+
+    assert len(ingest_calls) >= 1, "run_backfill was not called after watcher file event"


### PR DESCRIPTION
Closes #218

## Root Cause
Watcher was firing file-change events but no consumer subscribed to them. Events accumulated in the dispatch queue with zero subscribers, so `run_backfill` was never called on live file changes.

## Fix
Added `_watch_and_ingest()` coroutine (app.py) that:
- Subscribes to watcher events on startup
- Debounces rapid writes (2s window)
- Calls `run_backfill` on each event batch
- Logs confirmation: `Watcher ingest complete: sessions=N spans=N`

## Test
Regression test `test_watch_and_ingest_triggers_backfill`: file write → watcher event → `run_backfill` called.